### PR TITLE
docs: make CHANGELOG rule in CLAUDE.md concrete and actionable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,15 @@ Each package has its own `CLAUDE.md` with package-specific rules:
 - The SDK must be **built** (`make build-sdk`) before the UI can resolve it (UI reads from `dist/`)
 
 ### Documentation
-- **Mandatory docs** — README per package, CHANGELOG, docs/ at root for cross-cutting
-- **Update together** — Docs update with code in same PR
+- **Mandatory docs** — README per package, root `CHANGELOG.md`, `docs/` at root for cross-cutting
+- **Update together** — Docs update with code in the same PR
+
+### Changelog discipline
+Every PR with user-visible impact must add an entry under `## [Unreleased]` in `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format). User-visible means: anything that changes UI behavior, API surface, install/upgrade flow, configuration, or breaking changes — anything an upgrading user would want to know about. Skip for: pure refactors with no behavior change, internal test additions, dev-only tooling, typo fixes, doc-only PRs that aren't documenting a change.
+
+Entry format: one sentence, present tense, user-perspective. Group by intent — `Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`. Don't lead with the PR number; the diff already says that. Reference issues only when they add context the entry doesn't carry on its own.
+
+On release: rename `## [Unreleased]` to `## [vX.Y.Z] — YYYY-MM-DD` and add a fresh empty `[Unreleased]` block back at the top. The release tag is what cuts the version.
 
 ### Tech Stack
 - **Backend:** Python 3.12+, FastAPI, Neo4j 5, Pydantic v2, pytest


### PR DESCRIPTION
## Summary
- Existing rule listed CHANGELOG under "Mandatory docs" but the file doesn't exist and the rule didn't say what an entry should look like, when it's required, or what to skip.
- Replaces the bullet with a self-contained section: when is an entry required, what does it look like (one sentence, user-perspective, grouped by intent per Keep a Changelog), what gets skipped (refactors / typos / dev-only tooling), what happens on release.
- The actual \`CHANGELOG.md\` file plus retroactive entries lands in #11.

## Test plan
- [x] Diff is documentation-only — \`CLAUDE.md\` only
- [x] Wording is concrete enough to act on without reading the issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)