### PR TITLE
fix: render CONTAINS edges on the map and use PUT for asset edits

### DIFF
--- a/packages/api/src/holocron/core/services/graph_service.py
+++ b/packages/api/src/holocron/core/services/graph_service.py
@@ -33,6 +33,19 @@ from holocron.db.connection import Neo4jDriver
 
 logger = logging.getLogger(__name__)
 
+# Relation types that contribute edges to the data-landscape map. Kept as a
+# module-level constant so adding a new type doesn't require eyeballing a
+# string-embedded Cypher list. Order is irrelevant; the cypher renders
+# whatever's here as a static IN clause.
+_MAP_EDGE_TYPES: tuple[str, ...] = (
+    "OWNS",
+    "USES",
+    "FEEDS",
+    "CONTAINS",
+    "MEMBER_OF",
+    "APPLIES_TO",
+)
+
 # Deterministic seed so the layout is stable across requests/restarts —
 # tiles + client-side caching only work if positions don't drift.
 _LAYOUT_SEED = 42
@@ -214,11 +227,12 @@ class GraphService:
                 n.name AS name,
                 coalesce(n.type, n.severity, 'unknown') AS subtype
         """
-        edge_cypher = """
+        edge_types = ",".join(f"'{t}'" for t in _MAP_EDGE_TYPES)
+        edge_cypher = f"""
             MATCH (a)-[r]->(b)
             WHERE (a:Asset OR a:Actor OR a:Rule)
               AND (b:Asset OR b:Actor OR b:Rule)
-              AND type(r) IN ['OWNS','USES','FEEDS','MEMBER_OF','APPLIES_TO']
+              AND type(r) IN [{edge_types}]
             RETURN
                 coalesce(r.uid, elementId(r)) AS uid,
                 a.uid AS source,

--- a/packages/api/tests/unit/test_graph_service.py
+++ b/packages/api/tests/unit/test_graph_service.py
@@ -1,0 +1,30 @@
+"""Unit tests for the graph-map service.
+
+We don't hit Neo4j here — the layout + cache logic is exercised in
+``test_webhooks.py`` (via the invalidation listener). This file owns
+the structural invariants of the data-landscape map: which relation
+types contribute edges, and which kinds count as first-class nodes.
+The bar is "a release shouldn't be able to silently drop a relation
+type from the map" — that bug shipped in v0.0.x and surfaced as
+issue #4 (asset CONTAINS edges invisible).
+"""
+
+from __future__ import annotations
+
+from holocron.core.services.graph_service import _MAP_EDGE_TYPES
+from holocron.db.utils import ALLOWED_RELATIONSHIP_TYPES
+
+
+class TestMapEdgeTypes:
+    def test_includes_contains(self) -> None:
+        """Regression: CONTAINS is a real Asset->Asset relation (a system
+        contains its reports, an app contains its dashboards). It was
+        missing from the map's whitelist in v0.0.x — issue #4."""
+        assert "CONTAINS" in _MAP_EDGE_TYPES
+
+    def test_matches_allowed_relationship_types(self) -> None:
+        """The map should render every relation type the API actually
+        accepts. Drift between these two sets is what made #4 silently
+        invisible — a relation could be created, persisted, and never
+        appear on /map. Locking the equality here keeps that closed."""
+        assert frozenset(_MAP_EDGE_TYPES) == ALLOWED_RELATIONSHIP_TYPES

--- a/packages/ui/src/components/features/edit-asset-field-wizard.tsx
+++ b/packages/ui/src/components/features/edit-asset-field-wizard.tsx
@@ -124,7 +124,7 @@ function EditFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 			}
 
 			const res = await fetch(`/api/holocron/assets/${assetUid}`, {
-				method: "PATCH",
+				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify(payload),
 			});

--- a/packages/ui/src/components/features/edit-metadata-field-wizard.tsx
+++ b/packages/ui/src/components/features/edit-metadata-field-wizard.tsx
@@ -111,9 +111,8 @@ function EditFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 				entityKind === "asset"
 					? `/api/holocron/assets/${entityUid}`
 					: `/api/holocron/actors/${entityUid}`;
-			const method = entityKind === "asset" ? "PATCH" : "PUT";
 			const res = await fetch(url, {
-				method,
+				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ metadata: nextMetadata }),
 			});


### PR DESCRIPTION
Bundled because each is too small for its own PR.

## #4 — CONTAINS edges missing on /map

The map's edge query whitelisted 5 of the 6 valid relation types — CONTAINS was missing. Asset hierarchies (a system containing its reports, an app containing its dashboards) rendered as disconnected nodes even though the relation existed in the graph and the UI had a color slot reserved for it.

- Add CONTAINS to the whitelist.
- Refactor the whitelist out of the embedded Cypher into a module-level \`_MAP_EDGE_TYPES\` tuple so adding a relation type doesn't require editing a string.
- Add \`tests/unit/test_graph_service.py\` that asserts \`_MAP_EDGE_TYPES == ALLOWED_RELATIONSHIP_TYPES\`. A future relation type can't silently drop off the map.

Closes #4.

## #10 — Wizard edits silently 405'd on PATCH

\`edit-asset-field-wizard\` and \`edit-metadata-field-wizard\` sent \`PATCH\` to \`/api/holocron/assets/{uid}\`. Neither the Next.js proxy (route exports GET/PUT/DELETE only) nor the FastAPI route (\`@router.put\` only) accepts PATCH, so every wizard-driven asset edit failed. Only inline click-to-edit (which goes through \`useAsset.update\` → PUT) worked — which is why short renames seemed fine while longer URL paste-ins via ⌘K → \"Edit location\" appeared broken.

- Two-line swap: PATCH → PUT in both wizards.
- \`AssetUpdate\` is a partial-body model already, so single-field payloads are well-formed.
- Confirmed no other PATCH calls remain anywhere in \`packages/ui/src\`.

Closes #10.

## Test plan
- [x] \`pytest tests/unit/\` — 115 passed (2 new in \`test_graph_service.py\`)
- [x] \`mypy\` clean on changed Python file
- [x] UI \`tsc --noEmit\` clean
- [x] No new biome warnings introduced (the 4 reported in changed files are pre-existing on main — confirmed via stash)
- [ ] Manual: click an asset that contains another asset on /map → an edge between them, magenta. ⌘K → \"Edit location\" → paste a long URL → Save → toast \"Saved location\", value persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)