### PR TITLE
fix(ui): focus first interactive element on wizard cold open

### DIFF
--- a/packages/ui/src/components/features/wizard-shared.tsx
+++ b/packages/ui/src/components/features/wizard-shared.tsx
@@ -70,18 +70,23 @@ export function Kbd({ children }: { children: ReactNode }) {
 /* ------------------------------------------------------------------ */
 /* Wizard focus: DRY autofocus behaviour across every step/phase      */
 /*                                                                    */
-/* Every wizard shell wraps its content in WizardFocusProvider with   */
-/* `initialInteracted` set to `isNested` — so a wizard pushed on top  */
-/* of another one autofocuses immediately, while the first wizard     */
-/* opened from ⌘K stays quiet until the user does something.          */
+/* Every wizard shell wraps its content in WizardFocusProvider so     */
+/* `markInteracted` is reachable from anywhere in the tree, but the   */
+/* autofocus hooks below ignore it — they always focus on mount.      */
+/*                                                                    */
+/* History: the provider used to gate autofocus on `hasInteracted`    */
+/* so a wizard opened from ⌘K stayed "quiet" until the user pressed   */
+/* Next. That broke arrow-key navigation on cold open: nothing got    */
+/* focus, so ↑/↓ had no element to fire against (issue #7). The       */
+/* provider stays for backwards compat with call sites that still     */
+/* call `markInteracted`, but the autofocus contract is unconditional.*/
 /*                                                                    */
 /* Any primary element in any view just calls                         */
 /*                                                                    */
 /*     const ref = useRef<HTMLInputElement>(null);                    */
 /*     useWizardAutoFocus(ref);                                       */
 /*                                                                    */
-/* and it gets focus on mount iff the user has interacted with the    */
-/* wizard at all. No prop drilling, no per-dialog wiring.             */
+/* and it gets focus on mount. No prop drilling, no per-dialog wiring.*/
 /* ------------------------------------------------------------------ */
 
 interface WizardFocusValue {
@@ -120,21 +125,19 @@ export function useWizardFocus(): WizardFocusValue {
 }
 
 /**
- * Attach this to any primary element to make it autofocus on mount — but
- * only if the user has interacted with the wizard. First mount after ⌘K
- * stays unfocused; every subsequent view that mounts does focus.
+ * Attach this to any primary element to make it autofocus on mount.
  *
- * Captures `hasInteracted` at mount time so the element never re-focuses
- * unexpectedly if interaction state flips while the component is alive.
+ * Runs once per mount inside `requestAnimationFrame` so the focus call
+ * lands after Radix's own focus-management (we override
+ * `onOpenAutoFocus` to a noop on every wizard Dialog — without this
+ * hook the cold-open mount has no focused element and arrow keys go
+ * nowhere). Subsequent re-renders of the same component don't refocus
+ * because the effect only depends on the stable `ref` identity.
  */
 export function useWizardAutoFocus<T extends HTMLElement>(
 	ref: RefObject<T | null>,
 ): void {
-	const { hasInteracted } = useWizardFocus();
-	// Snapshot the value at mount — subsequent renders don't refocus.
-	const shouldFocusOnMountRef = useRef(hasInteracted);
 	useEffect(() => {
-		if (!shouldFocusOnMountRef.current) return;
 		const raf = requestAnimationFrame(() => {
 			ref.current?.focus();
 		});
@@ -161,11 +164,8 @@ export function useConditionalAutoFocus(
 	resolve: () => HTMLElement | null,
 	deps: ReadonlyArray<unknown>,
 ): void {
-	const { hasInteracted } = useWizardFocus();
-	const shouldFocusOnMountRef = useRef(hasInteracted);
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect(() => {
-		if (!shouldFocusOnMountRef.current) return;
 		const raf = requestAnimationFrame(() => {
 			resolve()?.focus();
 		});


### PR DESCRIPTION
Closes #7.

## What was broken

User reported: *"wizard arrow navigation on choice does not seem to work at all."*

The original triage pointed at \`EntityPicker\` as the culprit, but reading more carefully showed it already has full combobox/listbox arrow nav with proper ARIA (\`packages/ui/src/components/features/search/entity-picker.tsx:255-298\`). The real bug is broader and affects every wizard.

## Root cause

\`WizardFocusProvider\` was wired with \`initialInteracted={isNested}\`, so a top-level wizard opened from ⌘K mounted with \`hasInteracted=false\`. Both \`useWizardAutoFocus\` and \`useConditionalAutoFocus\` snapshotted that flag at mount and short-circuited:

\`\`\`ts
const shouldFocusOnMountRef = useRef(hasInteracted);
useEffect(() => {
  if (!shouldFocusOnMountRef.current) return;
  // ...focus
});
\`\`\`

Combined with the wizard Dialog's \`onOpenAutoFocus={(e) => e.preventDefault()}\` (which prevents Radix's default focus trap), this meant the first step rendered with no focused element. Arrow keys had nothing to fire against. Subsequent steps called \`markInteracted()\` and worked, which is why mid-flow steps felt fine.

## Fix

Drop the gate from both hooks. Always focus on mount.

\`WizardFocusProvider\` / \`useWizardFocus\` / \`markInteracted\` stay in place — they're imported by 13 wizard files and removing them would explode the diff. The provider's gate was the bug; removing it is the fix.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test --run\` — 94 passed (no regressions in the existing wizard-keys / wizard-shared / wizard-store / extensions / schema-ops suites)
- [ ] Manual: ⌘K → \"New asset\" → step 1 (Type) — first card has visible focus ring on render. Press ↓ — cursor moves immediately. No prior click required.
- [ ] Manual: ⌘K → \"New relation\" → source step — EntityPicker input has focus on render, type two letters, ↓ moves through results.
- [ ] Manual: a nested wizard (e.g. add maintainer → \"new person\" inline) still autofocuses immediately on the inner step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)