### PR TITLE
fix(ui): unblock page-level scroll on detail pages and tall wizards

### DIFF
--- a/packages/ui/src/app/actors/[uid]/page.tsx
+++ b/packages/ui/src/app/actors/[uid]/page.tsx
@@ -14,11 +14,11 @@ export default function ActorPage() {
 	const { data: actor, isLoading, error } = useActor(uid);
 
 	return (
-		<main className="w-full h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-4 gap-3 overflow-hidden">
+		<main className="w-full min-h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-4 gap-3">
 			<div className="shrink-0">
 				<BackToSearch />
 			</div>
-			<div className="flex-1 min-h-0 flex flex-col">
+			<div className="flex-1 flex flex-col">
 				<ActorDetail actor={actor} isLoading={isLoading} error={error} />
 			</div>
 		</main>

--- a/packages/ui/src/app/assets/[uid]/page.tsx
+++ b/packages/ui/src/app/assets/[uid]/page.tsx
@@ -14,11 +14,11 @@ export default function AssetPage() {
 	const { data: asset, isLoading, error } = useAsset(uid);
 
 	return (
-		<main className="w-full h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-4 gap-3 overflow-hidden">
+		<main className="w-full min-h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-4 gap-3">
 			<div className="shrink-0">
 				<BackToSearch />
 			</div>
-			<div className="flex-1 min-h-0 flex flex-col">
+			<div className="flex-1 flex flex-col">
 				<AssetDetail asset={asset} isLoading={isLoading} error={error} />
 			</div>
 		</main>

--- a/packages/ui/src/app/page.tsx
+++ b/packages/ui/src/app/page.tsx
@@ -166,8 +166,15 @@ function HomeInner() {
 		);
 	}
 
+	// Map mode wraps a WebGL canvas that genuinely needs a fixed viewport
+	// height; list mode just stacks results that should scroll naturally
+	// when they exceed the viewport (especially on shorter laptop screens).
+	const mainHeightClass =
+		mode === "map"
+			? "h-[calc(100dvh-3.625rem)] overflow-hidden"
+			: "min-h-[calc(100dvh-3.625rem)]";
 	return (
-		<main className="relative w-full h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-4 gap-4 overflow-hidden">
+		<main className={`relative w-full ${mainHeightClass} flex flex-col px-6 py-4 gap-4`}>
 			{/* Top bar — shared search input + mode toggle + result chip. */}
 			<div className="shrink-0 flex items-center gap-3">
 				<div className="flex-1 max-w-3xl">

--- a/packages/ui/src/app/rules/[uid]/page.tsx
+++ b/packages/ui/src/app/rules/[uid]/page.tsx
@@ -14,11 +14,11 @@ export default function RulePage() {
 	const { data: rule, isLoading, error } = useRule(uid);
 
 	return (
-		<main className="w-full h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-4 gap-3 overflow-hidden">
+		<main className="w-full min-h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-4 gap-3">
 			<div className="shrink-0">
 				<BackToSearch />
 			</div>
-			<div className="flex-1 min-h-0 flex flex-col">
+			<div className="flex-1 flex flex-col">
 				<RuleDetail rule={rule} isLoading={isLoading} error={error} />
 			</div>
 		</main>

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -51,8 +51,13 @@ function DialogContent({
 			<DialogOverlay />
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
+				// `max-h` + `overflow-y-auto` keep tall wizards (e.g. the
+				// 7-step asset create flow) reachable on shorter laptop
+				// viewports — without these, content past the dialog's
+				// vertical centre clipped off-screen and the Next/Back
+				// buttons could become unhittable.
 				className={cn(
-					"fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+					"fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
Closes #5.

## What was broken

On 14-15\" laptops (~1440-1680 wide, vertical real estate is the bottleneck), several pages and dialogs were locked to the viewport height with no fallback page-level scroll. Long content got clipped under the fold and there was no way to reach it.

## Changes

Three independent height locks, one fix per surface:

1. **Asset / actor / rule detail pages** — \`packages/ui/src/app/{assets,actors,rules}/[uid]/page.tsx\`. Replace \`h-[calc(100dvh-3.625rem)] ... overflow-hidden\` with \`min-h-[calc(100dvh-3.625rem)]\`. The wrapper now grows to fit content and the page scrolls naturally. Inner detail components don't have any \`overflow-*\` boundaries (verified) so dropping the parent's fixed height doesn't break their layout.

2. **Home page** — \`packages/ui/src/app/page.tsx\`. Mode-aware: map mode keeps \`h-[calc(...)] overflow-hidden\` because the WebGL canvas genuinely needs a fixed viewport height; list mode switches to \`min-h-[calc(...)]\` so search results scroll naturally when they exceed the viewport.

3. **Dialog component** — \`packages/ui/src/components/ui/dialog.tsx\`. Add \`max-h-[calc(100dvh-2rem)] overflow-y-auto\` to \`DialogContent\` so wizards taller than the viewport (e.g. the 7-step asset create flow) scroll inside the dialog. Without these the bottom of long wizards clipped off-screen and the Next/Back buttons could become unhittable.

## What's left alone

- **Schema editor page** (\`packages/ui/src/app/assets/[uid]/schema/page.tsx\`) — keeps its fixed height. The tree editor inside has a real \`overflow-auto\` boundary that needs a constrained parent. Changing it would just push the bug into the editor.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test --run\` — 94 passed (no UI regressions)
- [ ] Manual on 1440×900: open an asset detail page with many relations + long metadata + schema → page scrolls smoothly, all sections visible. Open the create-asset wizard → reach the last step, confirm the Save button is reachable.
- [ ] Manual: home in map mode keeps full-bleed canvas (no scrollbars), home in list mode with many results lets the page scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)