### PR TITLE
feat(ui): webhook management page at /settings/webhooks

### DIFF
--- a/packages/ui/src/app/api/holocron/webhooks/[uid]/route.ts
+++ b/packages/ui/src/app/api/holocron/webhooks/[uid]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { handleError } from "@/lib/api-route";
+import { holocron } from "@/lib/holocron";
+
+interface RouteParams {
+	params: Promise<{ uid: string }>;
+}
+
+/**
+ * GET /api/holocron/webhooks/:uid
+ * Get a single webhook by UID.
+ */
+export async function GET(_request: Request, { params }: RouteParams) {
+	try {
+		const { uid } = await params;
+		const webhook = await holocron.webhooks.get(uid);
+		return NextResponse.json(webhook);
+	} catch (error) {
+		return handleError(error);
+	}
+}
+
+/**
+ * PUT /api/holocron/webhooks/:uid
+ * Partial update. Setting `disabled: false` re-enables a webhook that
+ * was auto-disabled and clears the failure counter.
+ */
+export async function PUT(request: Request, { params }: RouteParams) {
+	try {
+		const { uid } = await params;
+		const body = await request.json();
+		const webhook = await holocron.webhooks.update(uid, body);
+		return NextResponse.json(webhook);
+	} catch (error) {
+		return handleError(error);
+	}
+}
+
+/**
+ * DELETE /api/holocron/webhooks/:uid
+ * Remove a webhook subscription.
+ */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+	try {
+		const { uid } = await params;
+		await holocron.webhooks.delete(uid);
+		return new NextResponse(null, { status: 204 });
+	} catch (error) {
+		return handleError(error);
+	}
+}

--- a/packages/ui/src/app/api/holocron/webhooks/[uid]/test/route.ts
+++ b/packages/ui/src/app/api/holocron/webhooks/[uid]/test/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { handleError } from "@/lib/api-route";
+import { holocron } from "@/lib/holocron";
+
+interface RouteParams {
+	params: Promise<{ uid: string }>;
+}
+
+/**
+ * POST /api/holocron/webhooks/:uid/test
+ * Fire a synthetic event at the receiver so admins can verify wiring
+ * without mutating live data. Returns `{ delivered: boolean }`. A
+ * failed delivery still counts toward the auto-disable threshold —
+ * same path real events take.
+ */
+export async function POST(_request: Request, { params }: RouteParams) {
+	try {
+		const { uid } = await params;
+		const result = await holocron.webhooks.test(uid);
+		return NextResponse.json(result);
+	} catch (error) {
+		return handleError(error);
+	}
+}

--- a/packages/ui/src/app/api/holocron/webhooks/route.ts
+++ b/packages/ui/src/app/api/holocron/webhooks/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { handleError, proxyJson } from "@/lib/api-route";
+import { holocron } from "@/lib/holocron";
+
+/**
+ * GET /api/holocron/webhooks
+ * List registered webhook subscribers (newest first). Query string is
+ * passed through so the Python API owns the pagination contract.
+ */
+export async function GET(request: Request) {
+	const { searchParams } = new URL(request.url);
+	const qs = searchParams.toString();
+	return proxyJson(`/api/v1/webhooks${qs ? `?${qs}` : ""}`);
+}
+
+/**
+ * POST /api/holocron/webhooks
+ * Register a new webhook. The HMAC `secret` in the response is the
+ * one-and-only time the client can capture it — the API will not
+ * surface it again.
+ */
+export async function POST(request: Request) {
+	try {
+		const body = await request.json();
+		const webhook = await holocron.webhooks.create(body);
+		return NextResponse.json(webhook, { status: 201 });
+	} catch (error) {
+		return handleError(error);
+	}
+}

--- a/packages/ui/src/app/settings/webhooks/page.tsx
+++ b/packages/ui/src/app/settings/webhooks/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import type { Webhook } from "@squat-collective/holocron-ts";
+import {
+	AlertCircle,
+	CheckCircle2,
+	Copy,
+	Plus,
+	Send,
+	Trash2,
+	XCircle,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { CreateWebhookDialog } from "@/components/features/settings/create-webhook-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GalaxySpinner } from "@/components/ui/galaxy-spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+	useDeleteWebhook,
+	useTestWebhook,
+	useUpdateWebhook,
+	useWebhooks,
+} from "@/hooks/use-webhooks";
+
+/**
+ * Workspace-level webhook subscription manager. Surfaces the auto-
+ * disable signal that's invisible from the API today: a webhook that
+ * silently stops firing after consecutive failures shows up here as
+ * "auto-disabled" with the last error and a one-click re-enable.
+ */
+export default function WebhooksSettingsPage() {
+	const { data, isLoading, error } = useWebhooks();
+	const [createOpen, setCreateOpen] = useState(false);
+
+	return (
+		<TooltipProvider>
+			<main className="w-full min-h-[calc(100dvh-3.625rem)] flex flex-col px-6 py-6 gap-4 max-w-5xl mx-auto">
+				<header className="flex items-start justify-between gap-4 flex-wrap">
+					<div>
+						<h1 className="text-2xl font-semibold">Webhooks</h1>
+						<p className="text-sm text-muted-foreground mt-1 max-w-xl">
+							Receivers get an HMAC-signed POST whenever a subscribed event
+							fires. After enough consecutive failures a webhook is
+							auto-disabled — re-enable it from the row to clear the failure
+							counter.
+						</p>
+					</div>
+					<Button onClick={() => setCreateOpen(true)}>
+						<Plus className="size-4" />
+						New webhook
+					</Button>
+				</header>
+
+				{isLoading ? (
+					<div className="flex justify-center py-16">
+						<GalaxySpinner size={120} label="Loading webhooks…" />
+					</div>
+				) : error ? (
+					<div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+						Failed to load webhooks: {error.message}
+					</div>
+				) : !data || data.items.length === 0 ? (
+					<EmptyState onCreate={() => setCreateOpen(true)} />
+				) : (
+					<div className="flex flex-col gap-2">
+						{data.items.map((webhook) => (
+							<WebhookRow key={webhook.uid} webhook={webhook} />
+						))}
+					</div>
+				)}
+
+				<CreateWebhookDialog open={createOpen} onOpenChange={setCreateOpen} />
+			</main>
+		</TooltipProvider>
+	);
+}
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+	return (
+		<Card className="border-dashed">
+			<CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+				<div className="size-12 rounded-full bg-muted/40 flex items-center justify-center">
+					<Send className="size-5 text-muted-foreground" />
+				</div>
+				<div>
+					<p className="font-medium">No webhooks yet</p>
+					<p className="text-sm text-muted-foreground mt-1 max-w-md">
+						Register a receiver URL to be notified when assets, actors, rules,
+						or relations change.
+					</p>
+				</div>
+				<Button onClick={onCreate}>
+					<Plus className="size-4" />
+					New webhook
+				</Button>
+			</CardContent>
+		</Card>
+	);
+}
+
+function WebhookRow({ webhook }: { webhook: Webhook }) {
+	const update = useUpdateWebhook(webhook.uid);
+	const del = useDeleteWebhook();
+	const test = useTestWebhook();
+
+	const isAutoDisabled = webhook.disabled && webhook.failure_count > 0;
+
+	return (
+		<Card>
+			<CardHeader className="pb-3">
+				<div className="flex items-start justify-between gap-3 flex-wrap">
+					<div className="min-w-0 flex-1">
+						<div className="flex items-center gap-2 flex-wrap">
+							<CardTitle className="text-base font-mono break-all">
+								{webhook.url}
+							</CardTitle>
+							<StatusBadge webhook={webhook} />
+						</div>
+						{webhook.description && (
+							<p className="text-sm text-muted-foreground mt-1.5">
+								{webhook.description}
+							</p>
+						)}
+					</div>
+					<div className="flex items-center gap-1.5">
+						{isAutoDisabled && (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										size="sm"
+										variant="outline"
+										onClick={() => update.mutate({ disabled: false })}
+										disabled={update.isPending}
+									>
+										Re-enable
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent>
+									Clear the failure counter and resume delivery.
+								</TooltipContent>
+							</Tooltip>
+						)}
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={() => test.mutate(webhook.uid)}
+									disabled={test.isPending || webhook.disabled}
+								>
+									<Send className="size-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								{webhook.disabled
+									? "Disabled — re-enable to test"
+									: "Send a synthetic test event"}
+							</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={() => {
+										navigator.clipboard.writeText(webhook.uid);
+										toast.success("Webhook UID copied");
+									}}
+								>
+									<Copy className="size-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Copy webhook UID</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={() => {
+										if (
+											!confirm(
+												`Delete this webhook?\n\n${webhook.url}\n\nThe receiver will stop getting events. This cannot be undone.`,
+											)
+										)
+											return;
+										del.mutate(webhook.uid);
+									}}
+									disabled={del.isPending}
+								>
+									<Trash2 className="size-4 text-destructive" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Delete webhook</TooltipContent>
+						</Tooltip>
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="text-sm space-y-1.5">
+				<MetaLine label="Events">
+					<div className="flex flex-wrap gap-1">
+						{webhook.events.map((evt) => (
+							<Badge key={evt} variant="secondary" className="font-mono text-[11px]">
+								{evt}
+							</Badge>
+						))}
+					</div>
+				</MetaLine>
+				<MetaLine label="Last fired">
+					{webhook.last_fired_at
+						? new Date(webhook.last_fired_at).toLocaleString()
+						: "never"}
+				</MetaLine>
+				{webhook.failure_count > 0 && (
+					<MetaLine label="Failures">
+						<span className="text-destructive">
+							{webhook.failure_count} consecutive
+							{webhook.last_error && (
+								<span className="text-muted-foreground ml-2 font-mono text-xs">
+									— {webhook.last_error}
+								</span>
+							)}
+						</span>
+					</MetaLine>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+function StatusBadge({ webhook }: { webhook: Webhook }) {
+	if (webhook.disabled && webhook.failure_count > 0) {
+		return (
+			<Badge variant="destructive" className="gap-1">
+				<XCircle className="size-3" />
+				Auto-disabled
+			</Badge>
+		);
+	}
+	if (webhook.disabled) {
+		return (
+			<Badge variant="outline" className="gap-1 text-muted-foreground">
+				<XCircle className="size-3" />
+				Disabled
+			</Badge>
+		);
+	}
+	if (webhook.failure_count > 0) {
+		return (
+			<Badge variant="outline" className="gap-1 text-amber-600 border-amber-600/40">
+				<AlertCircle className="size-3" />
+				Failing
+			</Badge>
+		);
+	}
+	return (
+		<Badge variant="outline" className="gap-1 text-emerald-600 border-emerald-600/40">
+			<CheckCircle2 className="size-3" />
+			Active
+		</Badge>
+	);
+}
+
+function MetaLine({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex items-start gap-2">
+			<span className="text-[10px] uppercase tracking-wide text-muted-foreground w-20 shrink-0 mt-1">
+				{label}
+			</span>
+			<div className="flex-1 min-w-0">{children}</div>
+		</div>
+	);
+}

--- a/packages/ui/src/components/features/settings/create-webhook-dialog.tsx
+++ b/packages/ui/src/components/features/settings/create-webhook-dialog.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import type { WebhookCreated } from "@squat-collective/holocron-ts";
+import { Check, Copy, Plus, Send } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateWebhook } from "@/hooks/use-webhooks";
+
+const EVENT_TOPICS = [
+	"asset.created",
+	"asset.updated",
+	"asset.deleted",
+	"actor.created",
+	"actor.updated",
+	"actor.deleted",
+	"relation.created",
+	"relation.deleted",
+	"rule.created",
+	"rule.updated",
+	"rule.deleted",
+] as const;
+
+export function CreateWebhookDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (next: boolean) => void;
+}) {
+	const create = useCreateWebhook();
+	const [created, setCreated] = useState<WebhookCreated | null>(null);
+	const [url, setUrl] = useState("");
+	const [description, setDescription] = useState("");
+	const [allEvents, setAllEvents] = useState(true);
+	const [selectedEvents, setSelectedEvents] = useState<Set<string>>(new Set());
+
+	const reset = () => {
+		setUrl("");
+		setDescription("");
+		setAllEvents(true);
+		setSelectedEvents(new Set());
+		setCreated(null);
+	};
+
+	const handleClose = (next: boolean) => {
+		if (!next) {
+			// Reset state once the dialog has closed so the next open is clean.
+			setTimeout(reset, 200);
+		}
+		onOpenChange(next);
+	};
+
+	const submit = async () => {
+		if (!url.trim()) return;
+		const events = allEvents ? ["*"] : Array.from(selectedEvents);
+		if (events.length === 0) {
+			toast.error("Pick at least one event topic, or check 'All events'.");
+			return;
+		}
+		try {
+			const result = await create.mutateAsync({
+				url: url.trim(),
+				events,
+				description: description.trim() || undefined,
+			});
+			setCreated(result);
+		} catch {
+			// useCreateWebhook surfaces the toast on error.
+		}
+	};
+
+	if (created) {
+		return (
+			<Dialog open={open} onOpenChange={handleClose}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Webhook registered — copy the secret now</DialogTitle>
+						<DialogDescription>
+							The HMAC secret below is shown <strong>only this once</strong>.
+							Store it in your receiver's signature verifier; the API will not
+							surface it again.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-3">
+						<div>
+							<Label className="text-xs uppercase tracking-wide text-muted-foreground">
+								URL
+							</Label>
+							<p className="font-mono text-sm break-all mt-1">{created.url}</p>
+						</div>
+						<div>
+							<Label className="text-xs uppercase tracking-wide text-muted-foreground">
+								HMAC secret
+							</Label>
+							<div className="flex items-center gap-2 mt-1">
+								<code className="font-mono text-sm bg-muted/40 px-2 py-1 rounded flex-1 break-all">
+									{created.secret}
+								</code>
+								<Button
+									type="button"
+									size="icon"
+									variant="ghost"
+									onClick={() => {
+										navigator.clipboard.writeText(created.secret);
+										toast.success("Secret copied");
+									}}
+								>
+									<Copy className="size-4" />
+								</Button>
+							</div>
+						</div>
+						<div className="text-xs text-muted-foreground">
+							Receivers verify each request via{" "}
+							<code className="font-mono">X-Holocron-Signature</code>:{" "}
+							<code className="font-mono">sha256=&lt;hmac&gt;</code>.
+						</div>
+					</div>
+					<DialogFooter>
+						<Button onClick={() => handleClose(false)}>
+							<Check className="size-4" />
+							Done
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		);
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={handleClose}>
+			<DialogContent className="sm:max-w-xl">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<Send className="size-4" />
+						New webhook
+					</DialogTitle>
+					<DialogDescription>
+						Register a receiver URL. Each subscribed event becomes an HMAC-signed
+						POST to this URL.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					<div className="space-y-1.5">
+						<Label htmlFor="webhook-url">Receiver URL</Label>
+						<Input
+							id="webhook-url"
+							type="url"
+							placeholder="https://hook.example.com/holocron"
+							value={url}
+							onChange={(e) => setUrl(e.target.value)}
+							autoFocus
+						/>
+						<p className="text-xs text-muted-foreground">
+							HTTPS recommended. The API does not enforce HTTPS to keep
+							localhost dev receivers easy.
+						</p>
+					</div>
+
+					<div className="space-y-1.5">
+						<Label htmlFor="webhook-description">Description (optional)</Label>
+						<Textarea
+							id="webhook-description"
+							placeholder="What this receiver does — e.g. 'Slack notifier for #data-alerts'."
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							rows={2}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label>Events to subscribe to</Label>
+						<label className="flex items-center gap-2 cursor-pointer">
+							<Checkbox
+								checked={allEvents}
+								onCheckedChange={(checked) => setAllEvents(checked === true)}
+							/>
+							<span className="text-sm font-medium">
+								All events (recommended for first setup)
+							</span>
+						</label>
+						{!allEvents && (
+							<div className="grid grid-cols-2 gap-1.5 mt-2">
+								{EVENT_TOPICS.map((topic) => {
+									const active = selectedEvents.has(topic);
+									return (
+										<Badge
+											key={topic}
+											asChild
+											variant={active ? "default" : "outline"}
+											className="cursor-pointer font-mono text-[11px] py-1 justify-start"
+										>
+											<button
+												type="button"
+												onClick={() => {
+													setSelectedEvents((prev) => {
+														const next = new Set(prev);
+														if (next.has(topic)) next.delete(topic);
+														else next.add(topic);
+														return next;
+													});
+												}}
+											>
+												{topic}
+											</button>
+										</Badge>
+									);
+								})}
+							</div>
+						)}
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button variant="ghost" onClick={() => handleClose(false)}>
+						Cancel
+					</Button>
+					<Button
+						onClick={submit}
+						disabled={create.isPending || !url.trim()}
+					>
+						<Plus className="size-4" />
+						{create.isPending ? "Registering…" : "Register"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/ui/src/extensions/built-in/navigation.ts
+++ b/packages/ui/src/extensions/built-in/navigation.ts
@@ -1,3 +1,4 @@
+import { Send } from "lucide-react";
 import { MapIcon } from "@/lib/icons";
 import type { Extension } from "../types";
 
@@ -22,6 +23,26 @@ export const navigationExtension: Extension = {
 			order: 10,
 			run: () => {
 				window.location.assign("/?mode=map");
+			},
+		},
+		{
+			id: "open-webhooks",
+			label: "Manage webhooks",
+			hint: "Outbound subscriptions for catalog events",
+			keywords: [
+				"webhooks",
+				"webhook",
+				"settings",
+				"integrations",
+				"hooks",
+				"events",
+				"subscribers",
+			],
+			group: "Navigate",
+			icon: Send,
+			order: 20,
+			run: () => {
+				window.location.assign("/settings/webhooks");
 			},
 		},
 	],

--- a/packages/ui/src/hooks/use-webhooks.ts
+++ b/packages/ui/src/hooks/use-webhooks.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import type {
+	Webhook,
+	WebhookCreate,
+	WebhookCreated,
+	WebhookUpdate,
+} from "@squat-collective/holocron-ts";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { queryKeys } from "@/lib/query-keys";
+
+interface WebhookList {
+	items: Webhook[];
+	total: number;
+}
+
+/**
+ * List registered webhooks. Polled every 30 s so the list reflects
+ * auto-disable / failure-count updates without manual refresh.
+ */
+export function useWebhooks() {
+	return useQuery<WebhookList>({
+		queryKey: queryKeys.webhooks.list(),
+		queryFn: async () => {
+			const res = await fetch("/api/holocron/webhooks");
+			if (!res.ok) throw new Error(`Failed to load webhooks (${res.status})`);
+			return res.json();
+		},
+		refetchInterval: 30_000,
+	});
+}
+
+/**
+ * Create a webhook. The resolved value contains the one-shot HMAC
+ * `secret` — callers MUST surface it to the user immediately, the API
+ * will not return it again.
+ */
+export function useCreateWebhook() {
+	const queryClient = useQueryClient();
+	return useMutation<WebhookCreated, Error, WebhookCreate>({
+		mutationFn: async (input) => {
+			const res = await fetch("/api/holocron/webhooks", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(input),
+			});
+			if (!res.ok) {
+				const body = await res.text();
+				throw new Error(body || `Create failed (${res.status})`);
+			}
+			return res.json();
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.webhooks.all });
+		},
+		onError: (err) => {
+			toast.error(err.message);
+		},
+	});
+}
+
+/**
+ * Partial update. Setting `disabled: false` re-enables a webhook that
+ * was auto-disabled and clears the failure counter.
+ */
+export function useUpdateWebhook(uid: string) {
+	const queryClient = useQueryClient();
+	return useMutation<Webhook, Error, WebhookUpdate>({
+		mutationFn: async (input) => {
+			const res = await fetch(`/api/holocron/webhooks/${uid}`, {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(input),
+			});
+			if (!res.ok) {
+				const body = await res.text();
+				throw new Error(body || `Update failed (${res.status})`);
+			}
+			return res.json();
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.webhooks.all });
+		},
+		onError: (err) => {
+			toast.error(err.message);
+		},
+	});
+}
+
+export function useDeleteWebhook() {
+	const queryClient = useQueryClient();
+	return useMutation<void, Error, string>({
+		mutationFn: async (uid) => {
+			const res = await fetch(`/api/holocron/webhooks/${uid}`, {
+				method: "DELETE",
+			});
+			if (!res.ok && res.status !== 204) {
+				const body = await res.text();
+				throw new Error(body || `Delete failed (${res.status})`);
+			}
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.webhooks.all });
+		},
+		onError: (err) => {
+			toast.error(err.message);
+		},
+	});
+}
+
+/**
+ * Fire a synthetic event at the receiver. Useful for verifying wiring
+ * after first registering a webhook. Failed deliveries count toward
+ * the auto-disable threshold the same way real events do.
+ */
+export function useTestWebhook() {
+	const queryClient = useQueryClient();
+	return useMutation<{ delivered: boolean }, Error, string>({
+		mutationFn: async (uid) => {
+			const res = await fetch(`/api/holocron/webhooks/${uid}/test`, {
+				method: "POST",
+			});
+			if (!res.ok) {
+				const body = await res.text();
+				throw new Error(body || `Test failed (${res.status})`);
+			}
+			return res.json();
+		},
+		onSuccess: (data, uid) => {
+			// Refetch — a failed test increments the failure counter on
+			// the receiver and might have flipped `disabled`.
+			queryClient.invalidateQueries({ queryKey: queryKeys.webhooks.all });
+			if (data.delivered) {
+				toast.success("Test event delivered");
+			} else {
+				toast.error(
+					"Test event failed — receiver did not return 2xx. Check the URL and the receiver logs.",
+				);
+			}
+		},
+		onError: (err) => {
+			toast.error(err.message);
+		},
+	});
+}

--- a/packages/ui/src/lib/query-keys.ts
+++ b/packages/ui/src/lib/query-keys.ts
@@ -39,4 +39,13 @@ export const queryKeys = {
 		all: ["search"] as const,
 		results: (query: string) => [...queryKeys.search.all, query] as const,
 	},
+
+	webhooks: {
+		all: ["webhooks"] as const,
+		lists: () => [...queryKeys.webhooks.all, "list"] as const,
+		list: (filters?: { limit?: number; offset?: number }) =>
+			[...queryKeys.webhooks.lists(), filters] as const,
+		details: () => [...queryKeys.webhooks.all, "detail"] as const,
+		detail: (uid: string) => [...queryKeys.webhooks.details(), uid] as const,
+	},
 } as const;


### PR DESCRIPTION
Closes #9.

## What lands

A workspace-level admin surface for webhooks at \`/settings/webhooks\`. Reachable via ⌘K → \"Manage webhooks\" (header stays sparse on purpose — that's the app's design language).

Features:

- **List view** with URL, subscribed events, last fired timestamp, and a status badge: **Active** / **Failing** / **Auto-disabled** / **Disabled**.
- **Send test event** per row — fires a synthetic event at the receiver via \`POST /webhooks/:uid/test\`. Failed deliveries surface as a toast and count toward auto-disable.
- **Re-enable** action on auto-disabled webhooks. Clears the failure counter via \`PUT { disabled: false }\`.
- **Copy UID** + **Delete** (with confirm) per row.
- **New webhook dialog** with URL + optional description + event filter (\"All events\" or pick-from-list). On success it flips into a one-shot **copy your secret** pane — the HMAC secret is shown only there, the API never surfaces it again.
- **30s polling** on the list query so auto-disable / failure-count flips show without manual refresh.

## Files

- \`src/app/settings/webhooks/page.tsx\` — list + per-row actions
- \`src/components/features/settings/create-webhook-dialog.tsx\` — register flow with secret reveal
- \`src/hooks/use-webhooks.ts\` — \`useWebhooks\`, \`useCreateWebhook\`, \`useUpdateWebhook\`, \`useDeleteWebhook\`, \`useTestWebhook\`
- \`src/app/api/holocron/webhooks/{route.ts,[uid]/route.ts,[uid]/test/route.ts}\` — Next.js proxy → SDK
- \`src/lib/query-keys.ts\` — \`webhooks\` key family
- \`src/extensions/built-in/navigation.ts\` — \"Manage webhooks\" command in ⌘K

## Test plan

- [x] \`bun run typecheck\` clean (UI)
- [x] \`bun run test --run\` — 94 passed
- [ ] Manual: ⌘K → \"webhooks\" → page loads with empty state. Click New webhook → enter a URL → see the secret pane. List shows the new row with **Active** badge. Click test event → toast (success or failure). Delete works with confirm.
- [ ] Manual: register a receiver that always 500s, fire 10 test events, confirm the row flips to **Auto-disabled** with the failure count + last error visible, and **Re-enable** clears it.

## Out of scope

- Per-row inline edit dialog (URL / events / description). Today the only mutation path beyond enable/disable is delete+recreate. The \`useUpdateWebhook\` mutation is already wired (used for re-enable), so an Edit dialog is a one-component follow-up.
- Webhook event log inspector — the API only tracks aggregate counters, not per-delivery history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)