### PR TITLE
feat: tag autosuggest end-to-end (API + SDK + UI combobox)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1447,6 +1447,28 @@
         }
       }
     },
+    "/api/v1/tags": {
+      "get": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "List Tags",
+        "description": "List every tag currently in use, sorted by usage count (descending).",
+        "operationId": "list_tags_api_v1_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/webhooks": {
       "post": {
         "tags": [
@@ -3499,6 +3521,50 @@
         ],
         "title": "SearchResponse",
         "description": "Cross-entity search results."
+      },
+      "TagListResponse": {
+        "properties": {
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagUsage"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tags",
+          "total"
+        ],
+        "title": "TagListResponse",
+        "description": "Distinct tags currently in use across the catalog. Sorted by\ncount descending, then name ascending \u2014 so a typeahead UI can show\nthe most-common tags first while staying deterministic."
+      },
+      "TagUsage": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Lowercase tag name as stored on the asset."
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Count",
+            "description": "Number of assets carrying this tag."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "count"
+        ],
+        "title": "TagUsage",
+        "description": "A tag that's currently in use on at least one asset, with its\ncatalog-wide usage count. Counts let UI consumers prefer the\ndominant spelling when offering suggestions (`pii (12)` vs.\n`PII (1)`)."
       },
       "ValidationError": {
         "properties": {

--- a/packages/api/src/holocron/api/routes/tags.py
+++ b/packages/api/src/holocron/api/routes/tags.py
@@ -1,0 +1,93 @@
+"""Tag aggregation endpoint.
+
+`GET /tags` returns every distinct tag in use across all assets, with
+catalog-wide usage counts. This is the data behind the asset-create
+wizard's tag autosuggest — without it users keep typing inconsistent
+spellings (`pii`, `PII`, `pii-data`) for the same conceptual tag.
+
+Tags live inside `metadata.tags` (a JSON array), and `metadata` is
+stored as a JSON-encoded string property on the Neo4j node — so
+aggregation can't use Cypher's `UNWIND` directly. We pull every
+asset's metadata, decode in Python, and tally. Acceptable at the
+scale this catalog targets (low thousands of assets).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from collections.abc import Iterable
+from typing import Any
+
+from fastapi import APIRouter
+
+from holocron.api.dependencies import get_neo4j_driver
+from holocron.api.schemas.tags import TagListResponse, TagUsage
+
+router = APIRouter(prefix="/tags", tags=["tags"])
+
+logger = logging.getLogger(__name__)
+
+
+def aggregate_tags(metadatas: Iterable[Any]) -> TagListResponse:
+    """Count tag usages across raw `metadata` values pulled from Neo4j.
+
+    Pure function, decoupled from the driver so it can be unit-tested.
+    Inputs are whatever the `a.metadata` property returns — typically
+    a JSON-encoded string (the asset repo's storage shape) or `None`
+    for assets without metadata. Anything that doesn't decode to a
+    dict with a list under `tags` is silently skipped.
+
+    Tags are normalised the same way the create wizard normalises them
+    on input: trimmed, leading `#` stripped, lowercased. Empty results
+    after normalisation are dropped.
+
+    Output is sorted by count descending, then name ascending — most-
+    used tags first, deterministic ordering across requests.
+    """
+    counts: Counter[str] = Counter()
+    for raw in metadatas:
+        if not raw:
+            continue
+        try:
+            metadata = json.loads(raw) if isinstance(raw, str) else raw
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(metadata, dict):
+            continue
+        tags = metadata.get("tags")
+        if not isinstance(tags, list):
+            continue
+        for tag in tags:
+            if not isinstance(tag, str):
+                continue
+            normalised = tag.strip().lstrip("#").lower()
+            if not normalised:
+                continue
+            counts[normalised] += 1
+
+    items = [
+        TagUsage(name=name, count=count)
+        for name, count in sorted(
+            counts.items(),
+            key=lambda pair: (-pair[1], pair[0]),
+        )
+    ]
+    return TagListResponse(tags=items, total=len(items))
+
+
+@router.get("", response_model=TagListResponse)
+async def list_tags() -> TagListResponse:
+    """List every tag currently in use, sorted by usage count (descending)."""
+    driver = get_neo4j_driver()
+    cypher = """
+        MATCH (a:Asset)
+        RETURN a.metadata AS metadata
+    """
+    metadatas: list[Any] = []
+    async with driver.session() as session:
+        result = await session.run(cypher)
+        async for record in result:
+            metadatas.append(record["metadata"])
+    return aggregate_tags(metadatas)

--- a/packages/api/src/holocron/api/schemas/tags.py
+++ b/packages/api/src/holocron/api/schemas/tags.py
@@ -1,0 +1,26 @@
+"""Tag schemas — surfaced from the `metadata.tags` array on assets."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class TagUsage(BaseModel):
+    """A tag that's currently in use on at least one asset, with its
+    catalog-wide usage count. Counts let UI consumers prefer the
+    dominant spelling when offering suggestions (`pii (12)` vs.
+    `PII (1)`).
+    """
+
+    name: str = Field(..., description="Lowercase tag name as stored on the asset.")
+    count: int = Field(..., ge=1, description="Number of assets carrying this tag.")
+
+
+class TagListResponse(BaseModel):
+    """Distinct tags currently in use across the catalog. Sorted by
+    count descending, then name ascending — so a typeahead UI can show
+    the most-common tags first while staying deterministic.
+    """
+
+    tags: list[TagUsage]
+    total: int

--- a/packages/api/src/holocron/main.py
+++ b/packages/api/src/holocron/main.py
@@ -19,6 +19,7 @@ from holocron.api.routes import (
     relations,
     rules,
     search,
+    tags,
     webhooks,
 )
 from holocron.core.exceptions import (
@@ -127,4 +128,5 @@ app.include_router(rules.router, prefix="/api/v1")
 app.include_router(search.router, prefix="/api/v1")
 app.include_router(graph.router, prefix="/api/v1")
 app.include_router(plugins_router, prefix="/api/v1")
+app.include_router(tags.router, prefix="/api/v1")
 app.include_router(webhooks.router, prefix="/api/v1")

--- a/packages/api/tests/unit/test_tags.py
+++ b/packages/api/tests/unit/test_tags.py
@@ -1,0 +1,99 @@
+"""Unit tests for the tag aggregation endpoint's pure logic.
+
+Skip the driver round-trip — `aggregate_tags` takes raw metadata
+values and returns a `TagListResponse`. Everything that matters
+(normalisation, sort order, malformed-input tolerance) is in there.
+"""
+
+from __future__ import annotations
+
+import json
+
+from holocron.api.routes.tags import aggregate_tags
+
+
+class TestAggregateTags:
+    def test_empty_input(self) -> None:
+        result = aggregate_tags([])
+        assert result.total == 0
+        assert result.tags == []
+
+    def test_counts_distinct_tags(self) -> None:
+        metadatas = [
+            json.dumps({"tags": ["pii", "gold-layer"]}),
+            json.dumps({"tags": ["pii"]}),
+            json.dumps({"tags": ["gold-layer", "mission-critical"]}),
+        ]
+        result = aggregate_tags(metadatas)
+        assert result.total == 3
+        names = {tag.name for tag in result.tags}
+        assert names == {"pii", "gold-layer", "mission-critical"}
+        by_name = {tag.name: tag.count for tag in result.tags}
+        assert by_name["pii"] == 2
+        assert by_name["gold-layer"] == 2
+        assert by_name["mission-critical"] == 1
+
+    def test_sorted_by_count_then_name(self) -> None:
+        """Most-used first; alphabetical tie-break keeps order stable
+        across requests so a UI consumer can cache without seeing
+        flicker."""
+        metadatas = [
+            json.dumps({"tags": ["b", "a", "c"]}),
+            json.dumps({"tags": ["a", "c"]}),
+            json.dumps({"tags": ["c"]}),
+        ]
+        result = aggregate_tags(metadatas)
+        names = [tag.name for tag in result.tags]
+        # c appears 3 times; a appears 2; b appears 1 — and 'a' wins
+        # the alphabetical tie-break against any equally-counted name.
+        assert names == ["c", "a", "b"]
+
+    def test_normalises_input(self) -> None:
+        """Mirrors the create wizard's normalisation: trim, strip
+        leading `#`, lowercase. Without this users see `pii`, `PII`,
+        `#pii` as three distinct suggestions even though the catalog
+        considers them the same tag."""
+        metadatas = [
+            json.dumps({"tags": ["PII"]}),
+            json.dumps({"tags": ["#pii"]}),
+            json.dumps({"tags": ["  pii  "]}),
+            json.dumps({"tags": ["pii"]}),
+        ]
+        result = aggregate_tags(metadatas)
+        assert result.total == 1
+        assert result.tags[0].name == "pii"
+        assert result.tags[0].count == 4
+
+    def test_skips_empty_after_normalisation(self) -> None:
+        """`#` alone or whitespace-only entries collapse to empty
+        strings — they shouldn't pollute the suggestion list."""
+        metadatas = [
+            json.dumps({"tags": ["#", "   ", "real-tag", ""]}),
+        ]
+        result = aggregate_tags(metadatas)
+        assert result.total == 1
+        assert result.tags[0].name == "real-tag"
+
+    def test_tolerates_malformed_input(self) -> None:
+        """Real-world data is messy. Non-string tags, dicts where a
+        list was expected, garbled JSON, plain `None` — all silently
+        skipped so one bad asset can't break the whole endpoint."""
+        metadatas = [
+            None,
+            "",
+            "not-json{",
+            json.dumps({"tags": "single-string-not-list"}),
+            json.dumps({"tags": [42, None, {"nested": "dict"}, "valid"]}),
+            json.dumps({"no_tags_key": True}),
+            json.dumps([1, 2, 3]),  # array at top level, not dict
+        ]
+        result = aggregate_tags(metadatas)
+        assert result.total == 1
+        assert result.tags[0].name == "valid"
+
+    def test_handles_already_decoded_metadata(self) -> None:
+        """Some call paths might hand us a dict directly (e.g. unit
+        tests, in-memory shims). Don't insist on JSON encoding."""
+        metadatas = [{"tags": ["hello", "world"]}]
+        result = aggregate_tags(metadatas)
+        assert result.total == 2

--- a/packages/sdk-ts/openapi.json
+++ b/packages/sdk-ts/openapi.json
@@ -1447,6 +1447,28 @@
         }
       }
     },
+    "/api/v1/tags": {
+      "get": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "List Tags",
+        "description": "List every tag currently in use, sorted by usage count (descending).",
+        "operationId": "list_tags_api_v1_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/webhooks": {
       "post": {
         "tags": [
@@ -3499,6 +3521,50 @@
         ],
         "title": "SearchResponse",
         "description": "Cross-entity search results."
+      },
+      "TagListResponse": {
+        "properties": {
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagUsage"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tags",
+          "total"
+        ],
+        "title": "TagListResponse",
+        "description": "Distinct tags currently in use across the catalog. Sorted by\ncount descending, then name ascending \u2014 so a typeahead UI can show\nthe most-common tags first while staying deterministic."
+      },
+      "TagUsage": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Lowercase tag name as stored on the asset."
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Count",
+            "description": "Number of assets carrying this tag."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "count"
+        ],
+        "title": "TagUsage",
+        "description": "A tag that's currently in use on at least one asset, with its\ncatalog-wide usage count. Counts let UI consumers prefer the\ndominant spelling when offering suggestions (`pii (12)` vs.\n`PII (1)`)."
       },
       "ValidationError": {
         "properties": {

--- a/packages/sdk-ts/src/client.ts
+++ b/packages/sdk-ts/src/client.ts
@@ -219,6 +219,21 @@ export type WebhookCreated = components["schemas"]["WebhookCreateResponse"];
 export type WebhookUpdate = components["schemas"]["WebhookUpdate"];
 
 /**
+ * A tag in use somewhere in the catalog, with its usage count.
+ * Counts let UI consumers prefer the dominant spelling when offering
+ * suggestions (`pii (12)` vs. `PII (1)`).
+ * @category Types
+ */
+export type TagUsage = components["schemas"]["TagUsage"];
+
+/**
+ * The `/tags` list response — every distinct tag currently in use,
+ * sorted by count descending then name ascending.
+ * @category Types
+ */
+export type TagList = components["schemas"]["TagListResponse"];
+
+/**
  * Body POSTed to subscriber URLs when an event fires. The canonical
  * `topic` (`"<entity>.<action>"`) lets receivers route by string
  * without reading both `action` and `entity_type`.
@@ -940,6 +955,43 @@ export class HolocronClient {
 					total: result.total,
 				};
 			},
+		},
+	};
+
+	/**
+	 * Tag operations — surface what's already in the catalog so forms
+	 * can autosuggest. Tags live on `Asset.metadata.tags` (free-form
+	 * strings, normalised lowercase server-side); there's no separate
+	 * tag entity.
+	 *
+	 * @category Tags
+	 */
+	readonly tags = {
+		/**
+		 * List every distinct tag currently in use across all assets,
+		 * sorted by usage count (most-used first; alphabetical
+		 * tie-break for deterministic ordering across requests).
+		 *
+		 * @example
+		 * ```typescript
+		 * const { tags } = await client.tags.list();
+		 * for (const { name, count } of tags) {
+		 *   console.log(`${name} — ${count} asset(s)`);
+		 * }
+		 * ```
+		 */
+		list: async (): Promise<TagList> => {
+			const { data, error, response } = await this.client.GET("/api/v1/tags");
+			// `/tags` takes no params, so FastAPI emits no 422 schema and
+			// openapi-fetch types `error` / `response.status` as `never` —
+			// fall through to the same shape the `health()` endpoint uses.
+			if (error)
+				throw createApiError(
+					"list tags",
+					error,
+					(response as Response | undefined)?.status,
+				);
+			return data;
 		},
 	};
 

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -32,6 +32,8 @@ export type {
 	WebhookCreated,
 	WebhookUpdate,
 	WebhookEventPayload,
+	TagUsage,
+	TagList,
 } from "./client";
 
 // Errors

--- a/packages/sdk-ts/src/types/api.ts
+++ b/packages/sdk-ts/src/types/api.ts
@@ -379,6 +379,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Tags
+         * @description List every tag currently in use, sorted by usage count (descending).
+         */
+        get: operations["list_tags_api_v1_tags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/webhooks": {
         parameters: {
             query?: never;
@@ -1240,6 +1260,37 @@ export interface components {
             items: (components["schemas"]["AssetHit"] | components["schemas"]["ContainerHit"] | components["schemas"]["FieldHit"] | components["schemas"]["ActorHit"] | components["schemas"]["RuleHit"])[];
             /** Total */
             total: number;
+        };
+        /**
+         * TagListResponse
+         * @description Distinct tags currently in use across the catalog. Sorted by
+         *     count descending, then name ascending — so a typeahead UI can show
+         *     the most-common tags first while staying deterministic.
+         */
+        TagListResponse: {
+            /** Tags */
+            tags: components["schemas"]["TagUsage"][];
+            /** Total */
+            total: number;
+        };
+        /**
+         * TagUsage
+         * @description A tag that's currently in use on at least one asset, with its
+         *     catalog-wide usage count. Counts let UI consumers prefer the
+         *     dominant spelling when offering suggestions (`pii (12)` vs.
+         *     `PII (1)`).
+         */
+        TagUsage: {
+            /**
+             * Name
+             * @description Lowercase tag name as stored on the asset.
+             */
+            name: string;
+            /**
+             * Count
+             * @description Number of assets carrying this tag.
+             */
+            count: number;
         };
         /** ValidationError */
         ValidationError: {
@@ -2245,6 +2296,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_tags_api_v1_tags_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagListResponse"];
                 };
             };
         };

--- a/packages/ui/src/app/api/holocron/tags/route.ts
+++ b/packages/ui/src/app/api/holocron/tags/route.ts
@@ -1,0 +1,9 @@
+import { proxyJson } from "@/lib/api-route";
+
+/**
+ * GET /api/holocron/tags
+ * List every distinct tag currently in use across assets, with counts.
+ */
+export async function GET() {
+	return proxyJson("/api/v1/tags");
+}

--- a/packages/ui/src/components/features/create-asset-wizard.tsx
+++ b/packages/ui/src/components/features/create-asset-wizard.tsx
@@ -19,6 +19,7 @@ import {
 import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EntityPicker, type TailOption } from "@/components/features/search/entity-picker";
+import { TagAutocompleteInput } from "@/components/features/tag-autocomplete-input";
 import {
 	Kbd,
 	Stepper,
@@ -1023,27 +1024,16 @@ function StepTags({ value, onChange }: { value: string[]; onChange: (v: string[]
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	useWizardAutoFocus(inputRef);
 
-	const add = (raw: string) => {
-		const normalized = raw.trim().replace(/^#/, "").toLowerCase();
-		if (!normalized) return;
-		if (value.includes(normalized)) return;
-		onChange([...value, normalized]);
+	const add = (normalised: string) => {
+		if (!normalised) return;
+		if (value.includes(normalised)) return;
+		onChange([...value, normalised]);
 		setDraft("");
 		inputRef.current?.focus();
 	};
 
-	const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
-		if (e.metaKey || e.ctrlKey) return;
-		if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
-			if (draft.trim().length === 0) return;
-			e.preventDefault();
-			add(draft);
-			return;
-		}
-		if (e.key === "Backspace" && draft === "" && value.length > 0) {
-			e.preventDefault();
-			onChange(value.slice(0, -1));
-		}
+	const onBackspaceEmpty = () => {
+		if (value.length > 0) onChange(value.slice(0, -1));
 	};
 
 	return (
@@ -1052,7 +1042,7 @@ function StepTags({ value, onChange }: { value: string[]; onChange: (v: string[]
 				<h3 className="text-xl font-semibold">Any tags?</h3>
 				<p className="text-sm text-muted-foreground">
 					Free-form labels to help people filter. Optional — press <Kbd>↵</Kbd> or <Kbd>,</Kbd> to
-					add.
+					add. Existing tags from the catalog appear as suggestions.
 				</p>
 			</div>
 			{value.length > 0 && (
@@ -1077,13 +1067,14 @@ function StepTags({ value, onChange }: { value: string[]; onChange: (v: string[]
 					))}
 				</div>
 			)}
-			<Input
-				ref={inputRef}
+			<TagAutocompleteInput
+				inputRef={inputRef}
 				value={draft}
-				onChange={(e) => setDraft(e.target.value)}
-				onKeyDown={handleKey}
+				onValueChange={setDraft}
+				onAdd={add}
+				onBackspaceEmpty={onBackspaceEmpty}
+				excluded={value}
 				placeholder="e.g. pii, gold-layer, mission-critical…"
-				className="h-11"
 			/>
 		</div>
 	);

--- a/packages/ui/src/components/features/tag-autocomplete-input.tsx
+++ b/packages/ui/src/components/features/tag-autocomplete-input.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { Tag } from "lucide-react";
+import { type KeyboardEvent, useId, useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { useTagsCatalog } from "@/hooks/use-tags-catalog";
+import { cn } from "@/lib/utils";
+
+/**
+ * Tag input with autosuggest. Wraps a plain `<Input>` and overlays a
+ * dropdown listbox of catalog tags that match the current draft. Free-
+ * text entry still works (Enter / comma / Tab on the typed string),
+ * keyboard navigation across the dropdown follows the same pattern as
+ * the EntityPicker (combobox + listbox ARIA, roving cursor).
+ *
+ * Suggestions are filtered + ordered client-side from the cached
+ * `/tags` payload, so typing has no per-keystroke network cost. We
+ * exclude tags the user has already added and rank by usage count
+ * (most-used first) so the dominant spelling surfaces.
+ */
+export interface TagAutocompleteInputProps {
+	/** Current draft (controlled). */
+	value: string;
+	onValueChange: (next: string) => void;
+	/** Called with a normalised tag (lowercased, `#`-stripped, trimmed). */
+	onAdd: (normalised: string) => void;
+	/** Called when Backspace is pressed on an empty draft. */
+	onBackspaceEmpty?: () => void;
+	/** Tags already chosen on this form — excluded from suggestions. */
+	excluded: readonly string[];
+	placeholder?: string;
+	inputRef?: React.RefObject<HTMLInputElement | null>;
+	/** Maximum suggestions to display (default 8). */
+	maxSuggestions?: number;
+}
+
+const DEFAULT_MAX = 8;
+
+function normalise(raw: string): string {
+	return raw.trim().replace(/^#/, "").toLowerCase();
+}
+
+export function TagAutocompleteInput({
+	value,
+	onValueChange,
+	onAdd,
+	onBackspaceEmpty,
+	excluded,
+	placeholder,
+	inputRef,
+	maxSuggestions = DEFAULT_MAX,
+}: TagAutocompleteInputProps) {
+	const { data } = useTagsCatalog();
+	const [cursor, setCursor] = useState(-1);
+	const baseId = useId();
+	const listboxId = `${baseId}-tags-list`;
+	const optionId = (i: number) => `${baseId}-tag-${i}`;
+
+	const draft = normalise(value);
+	const excludedSet = useMemo(() => new Set(excluded), [excluded]);
+
+	const suggestions = useMemo(() => {
+		if (!data) return [];
+		if (draft.length === 0) return [];
+		return data.tags
+			.filter((t) => !excludedSet.has(t.name) && t.name.includes(draft))
+			.slice(0, maxSuggestions);
+	}, [data, draft, excludedSet, maxSuggestions]);
+
+	const showDropdown = suggestions.length > 0;
+	// `-1` means cursor is on the input (Enter adds the literal typed
+	// text); `0..N-1` selects a suggestion (Enter adds that one).
+	const safeCursor = Math.min(Math.max(cursor, -1), suggestions.length - 1);
+
+	const commitSuggestion = (idx: number) => {
+		const pick = suggestions[idx];
+		if (pick) {
+			onAdd(pick.name);
+			setCursor(-1);
+		}
+	};
+
+	const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.metaKey || e.ctrlKey) return;
+
+		if (e.key === "ArrowDown") {
+			if (!showDropdown) return;
+			e.preventDefault();
+			setCursor((i) => Math.min(i + 1, suggestions.length - 1));
+			return;
+		}
+		if (e.key === "ArrowUp") {
+			if (!showDropdown) return;
+			e.preventDefault();
+			setCursor((i) => Math.max(i - 1, -1));
+			return;
+		}
+		if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
+			if (showDropdown && safeCursor >= 0) {
+				e.preventDefault();
+				commitSuggestion(safeCursor);
+				return;
+			}
+			if (value.trim().length === 0) return;
+			e.preventDefault();
+			const normalised = normalise(value);
+			if (normalised) onAdd(normalised);
+			setCursor(-1);
+			return;
+		}
+		if (e.key === "Escape" && showDropdown) {
+			e.preventDefault();
+			setCursor(-1);
+			return;
+		}
+		if (e.key === "Backspace" && value === "" && onBackspaceEmpty) {
+			e.preventDefault();
+			onBackspaceEmpty();
+		}
+	};
+
+	return (
+		<div className="relative">
+			<Input
+				ref={inputRef}
+				value={value}
+				onChange={(e) => {
+					onValueChange(e.target.value);
+					setCursor(-1);
+				}}
+				onKeyDown={handleKey}
+				placeholder={placeholder}
+				className="h-11"
+				role="combobox"
+				aria-autocomplete="list"
+				aria-expanded={showDropdown}
+				aria-controls={showDropdown ? listboxId : undefined}
+				aria-activedescendant={
+					showDropdown && safeCursor >= 0 ? optionId(safeCursor) : undefined
+				}
+			/>
+			{showDropdown && (
+				<ul
+					id={listboxId}
+					role="listbox"
+					className="absolute z-20 top-full left-0 right-0 mt-1.5 rounded-md border border-primary/15 bg-popover shadow-lg shadow-primary/10 overflow-hidden max-h-64 overflow-y-auto"
+				>
+					{suggestions.map((tag, idx) => {
+						const active = idx === safeCursor;
+						return (
+							<li
+								key={tag.name}
+								id={optionId(idx)}
+								role="option"
+								aria-selected={active}
+							>
+								<button
+									type="button"
+									onClick={() => commitSuggestion(idx)}
+									onMouseEnter={() => setCursor(idx)}
+									className={cn(
+										"w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
+										active ? "bg-primary/10" : "hover:bg-muted/40",
+									)}
+								>
+									<Tag className="size-3.5 text-primary shrink-0" />
+									<span className="flex-1 truncate font-mono text-[13px]">
+										{tag.name}
+									</span>
+									<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+										{tag.count}
+									</span>
+								</button>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/packages/ui/src/hooks/use-tags-catalog.ts
+++ b/packages/ui/src/hooks/use-tags-catalog.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import type { TagList } from "@squat-collective/holocron-ts";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Fetch the catalog-wide tag list with usage counts. Used to power
+ * the asset-create wizard's tag autosuggest, so a 5-minute stale
+ * window is plenty — typing-induced refetches would just waste
+ * round-trips.
+ */
+export function useTagsCatalog() {
+	return useQuery<TagList>({
+		queryKey: ["tags-catalog"],
+		queryFn: async () => {
+			const res = await fetch("/api/holocron/tags");
+			if (!res.ok) throw new Error(`Failed to load tags (${res.status})`);
+			return res.json();
+		},
+		staleTime: 5 * 60 * 1000,
+	});
+}


### PR DESCRIPTION
Closes #6.

## What lands

Three layers, top to bottom:

1. **API** — \`GET /api/v1/tags\` returns every distinct tag in use across the catalog with usage counts, sorted by count desc / name asc.
2. **SDK** — \`client.tags.list()\` returning \`TagList = { tags: TagUsage[], total }\`. New types exported.
3. **UI** — \`TagAutocompleteInput\` component: a combobox over the catalog tags, plugged into the asset-create wizard's \`StepTags\`. Free-form entry still works (Enter/comma/Tab on typed text), arrow keys navigate the dropdown, ranking by usage count surfaces the dominant spelling first.

## Implementation notes

- Tags live on \`Asset.metadata.tags\` as JSON-encoded strings on the Neo4j node. Aggregation can't use Cypher's \`UNWIND\` directly — we pull every asset's metadata and tally in Python via a pure \`aggregate_tags()\` function. Acceptable at low-thousands-of-assets scale.
- \`aggregate_tags()\` mirrors the wizard's input normalisation (trim, strip leading \`#\`, lowercase) so \`pii\`, \`PII\`, \`#pii\`, and \`  pii  \` all collapse onto the same suggestion.
- 7 unit tests cover the aggregation: counting, sort order, normalisation, malformed-input tolerance, and already-decoded metadata.
- SDK \`client.tags.list()\` follows the \`health()\` pattern for routes that don't emit a \`422\` schema (no params → no validation → \`error\` typed as \`never\`).
- UI combobox follows the existing \`EntityPicker\` ARIA pattern: \`role=\"combobox\"\` + \`role=\"listbox\"\` + \`aria-activedescendant\` for screen readers, roving cursor for keyboard nav.

## Test plan

- [x] API: \`pytest tests/unit/\` — 122 passed (7 new).
- [x] API: \`mypy src/holocron/api/routes/tags.py src/holocron/api/schemas/tags.py\` clean. (The 27 mypy errors in the full \`src/\` are all pre-existing on main — confirmed via stash.)
- [x] SDK: \`bun run typecheck\` clean, 58 model unit tests pass, build emits valid \`dist/index.js\`.
- [x] UI: \`bun run typecheck\` clean, \`bun run test --run\` 94 passed.
- [ ] Manual: open create-asset wizard → reach the Tags step → type \`pi\` → see existing \`pii\` suggested with usage count → ↓ + Enter picks it. Without the dropdown selection, Enter still adds the literal typed text (free-form path).

## Out of scope

- Tag editing on existing assets (the field is create-only today).
- \`tag:foo\` prefix in the search query parser.
- Tag input on actors / rules (no tag step in those wizards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)