### PR TITLE
fix(api,ui): wizard pickers filter by kind/type server-side (#32)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1308,6 +1308,48 @@
               "title": "Limit"
             },
             "description": "Max items to return"
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict results to one or more kinds (asset / actor / container / field / rule). Repeat the param for multiple values. Intersects with any `kind:` prefix typed in the query \u2014 wizards that already know what's valid for a step pass this so a globally-ranked top-N can't squeeze the relevant kind out.",
+              "title": "Kind"
+            },
+            "description": "Restrict results to one or more kinds (asset / actor / container / field / rule). Repeat the param for multiple values. Intersects with any `kind:` prefix typed in the query \u2014 wizards that already know what's valid for a step pass this so a globally-ranked top-N can't squeeze the relevant kind out."
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Type filter, applied per-kind: asset.type for `kind=asset` (dataset / report / process / system / hierarchical members), actor.type for `kind=actor` (person / group), and severity for `kind=rule` (info / warning / critical). Mixed-kind type lists are routed to the right bucket automatically.",
+              "title": "Type"
+            },
+            "description": "Type filter, applied per-kind: asset.type for `kind=asset` (dataset / report / process / system / hierarchical members), actor.type for `kind=actor` (person / group), and severity for `kind=rule` (info / warning / critical). Mixed-kind type lists are routed to the right bucket automatically."
           }
         ],
         "responses": {

--- a/packages/api/src/holocron/api/routes/search.py
+++ b/packages/api/src/holocron/api/routes/search.py
@@ -16,6 +16,28 @@ async def search(
     service: SearchServiceDep,
     q: str = Query("", description="Free-text query"),
     limit: int = Query(50, ge=1, le=500, description="Max items to return"),
+    kind: list[str] | None = Query(
+        None,
+        description=(
+            "Restrict results to one or more kinds "
+            "(asset / actor / container / field / rule). Repeat the "
+            "param for multiple values. Intersects with any `kind:` "
+            "prefix typed in the query — wizards that already know "
+            "what's valid for a step pass this so a globally-ranked "
+            "top-N can't squeeze the relevant kind out."
+        ),
+    ),
+    type: list[str] | None = Query(
+        None,
+        description=(
+            "Type filter, applied per-kind: asset.type for `kind=asset` "
+            "(dataset / report / process / system / hierarchical "
+            "members), actor.type for `kind=actor` (person / group), "
+            "and severity for `kind=rule` (info / warning / critical). "
+            "Mixed-kind type lists are routed to the right bucket "
+            "automatically."
+        ),
+    ),
 ) -> SearchResponse:
     """Search across assets, actors, rules and schema nodes.
 
@@ -23,4 +45,4 @@ async def search(
     (asset / container / field / actor / rule). Empty queries return
     an empty list — the UI treats empty search as "show nothing yet".
     """
-    return await service.search(q, limit=limit)
+    return await service.search(q, limit=limit, kinds=kind, types=type)

--- a/packages/api/src/holocron/core/services/search_service.py
+++ b/packages/api/src/holocron/core/services/search_service.py
@@ -15,6 +15,8 @@ so a literal name match always beats pure semantic similarity. See
 import logging
 from typing import Any
 
+from holocron.api.schemas.actors import ActorType
+from holocron.api.schemas.assets import AssetType
 from holocron.api.schemas.search import (
     ActorHit,
     AssetHit,
@@ -25,7 +27,7 @@ from holocron.api.schemas.search import (
 from holocron.core.services.actor_service import ActorService
 from holocron.core.services.asset_service import AssetService
 from holocron.core.services.embedding_service import EmbeddingService
-from holocron.core.services.query_parser import parse_query
+from holocron.core.services.query_parser import HitKind, _ALL_KINDS, parse_query
 from holocron.core.services.rule_service import RuleService
 from holocron.core.services.search_haystacks import (
     actor_haystack,
@@ -61,7 +63,13 @@ class SearchService:
         self.actor_service = actor_service
         self.rule_service = rule_service
 
-    async def search(self, query: str, limit: int = 50) -> SearchResponse:
+    async def search(
+        self,
+        query: str,
+        limit: int = 50,
+        kinds: list[str] | None = None,
+        types: list[str] | None = None,
+    ) -> SearchResponse:
         """Return hits matching `query` across assets, actors, rules + schemas.
 
         The query supports a small DSL (see :py:mod:`query_parser`):
@@ -71,6 +79,20 @@ class SearchService:
         Kind prefixes narrow the search, quoted phrases require a literal
         substring, `-term` excludes matches. Leftover bare words power the
         semantic vector search.
+
+        Optional explicit filters:
+        - `kinds`: only return hits of the listed kinds
+          (`asset`/`actor`/`container`/`field`/`rule`). Intersects with
+          any `kind:` prefixes the user typed — wizards that already
+          know what's valid for a step pass this so a globally-ranked
+          top-N can't squeeze the relevant kind out.
+        - `types`: type filter applied based on the surviving kind:
+          for `asset` this filters on `asset.type` (dataset / report /
+          process / system / hierarchical members); for `actor` on
+          `actor.type` (person / group); for `rule` on `severity`
+          (info / warning / critical). Mixed-kind type filters are
+          honoured per-kind — `kinds=asset,actor & types=dataset,person`
+          works as expected.
 
         Results are **interleaved by cosine-similarity score** across all
         kinds — so "rules about PII" surfaces the right rule first even
@@ -90,6 +112,50 @@ class SearchService:
             [parsed.text, *parsed.exact_phrases]
         ).strip()
         allowed = parsed.allowed_kinds
+
+        # Explicit `kinds` from the caller intersect with whatever the
+        # query parser inferred. If the parser was unconstrained
+        # (`allowed_kinds` defaulted to all), the explicit set wins
+        # outright. If both sides constrained, we keep only the overlap
+        # — a wizard saying "actor only" plus a user typing `ds:foo`
+        # legitimately produces no hits and we shouldn't quietly fall
+        # through to all actors.
+        #
+        # Filter the incoming list to known HitKind values so a typo
+        # never widens the surface; unknown values are dropped silently
+        # rather than 422'd because the route is also reachable from
+        # plain link-clicks where strictness would only confuse users.
+        if kinds:
+            explicit_kinds: set[HitKind] = {
+                k for k in kinds if k in _ALL_KINDS
+            }
+            if parsed.kinds:
+                allowed = parsed.kinds & explicit_kinds
+            else:
+                allowed = explicit_kinds
+
+        # Explicit `types`: split into per-kind buckets so each ranker
+        # can apply its own filter independently. We intentionally don't
+        # error on unknown values — callers may pass a mixed list (e.g.
+        # `[\"dataset\",\"person\"]` for `kinds=[\"asset\",\"actor\"]`)
+        # and we route each value to the bucket it maps to.
+        explicit_asset_types: set[str] | None = None
+        explicit_actor_types: set[str] | None = None
+        explicit_severities: set[str] | None = None
+        if types:
+            asset_type_pool = {at.value for at in AssetType}
+            actor_type_pool = {at.value for at in ActorType}
+            severity_pool = {"info", "warning", "critical"}
+            type_set = {t for t in types if t}
+            asset_t = type_set & asset_type_pool
+            actor_t = type_set & actor_type_pool
+            sev_t = type_set & severity_pool
+            if asset_t:
+                explicit_asset_types = asset_t
+            if actor_t:
+                explicit_actor_types = actor_t
+            if sev_t:
+                explicit_severities = sev_t
 
         # Resolve graph-aware filters to sets of allowed uids. `None` means
         # "no filter"; an empty set means "the filter matched nothing, so
@@ -150,6 +216,15 @@ class SearchService:
                         a.type.value if hasattr(a.type, "value") else str(a.type)
                     )
                     == parsed.asset_type
+                ]
+            if explicit_asset_types is not None:
+                ranked_assets = [
+                    (a, s)
+                    for a, s in ranked_assets
+                    if (
+                        a.type.value if hasattr(a.type, "value") else str(a.type)
+                    )
+                    in explicit_asset_types
                 ]
             asset_count = 0
             for asset, asset_score in ranked_assets:
@@ -241,6 +316,15 @@ class SearchService:
                     )
                     == parsed.actor_type
                 ]
+            if explicit_actor_types is not None:
+                ranked_actors = [
+                    (a, s)
+                    for a, s in ranked_actors
+                    if (
+                        a.type.value if hasattr(a.type, "value") else str(a.type)
+                    )
+                    in explicit_actor_types
+                ]
             actor_count = 0
             for actor, score in ranked_actors:
                 if actor_count >= PER_KIND_CAP:
@@ -289,6 +373,17 @@ class SearchService:
                         else str(r.severity)
                     )
                     == parsed.severity
+                ]
+            if explicit_severities is not None:
+                ranked_rules = [
+                    (r, s)
+                    for r, s in ranked_rules
+                    if (
+                        r.severity.value
+                        if hasattr(r.severity, "value")
+                        else str(r.severity)
+                    )
+                    in explicit_severities
                 ]
             rule_count = 0
             for rule, score in ranked_rules:

--- a/packages/api/tests/integration/test_search.py
+++ b/packages/api/tests/integration/test_search.py
@@ -226,3 +226,105 @@ class TestSearchEndpoint:
         assert any(
             i["kind"] == "asset" and i["uid"] == asset_uid for i in items
         )
+
+
+class TestSearchKindAndTypeFilters:
+    """Server-side `kind` + `type` filters from #32.
+
+    Wizards pass these to keep allowed-kind hits from getting squeezed
+    out of the globally-ranked top-N. The previous client-side filter
+    only saw the first 20 results, so a query like "data" with a
+    full catalog could leave the wizard's allowed kind missing
+    entirely.
+    """
+
+    async def test_kind_asset_returns_only_assets(self, client: AsyncClient) -> None:
+        asset_uid = await _seed_asset(client, name="Customer Data")
+        await _seed_actor(client, name="Customer Dan")
+        await _seed_rule(client, name="Customer Data Quality", description="x")
+
+        response = await client.get(
+            "/api/v1/search",
+            params={"q": "customer", "kind": "asset"},
+        )
+        items = response.json()["items"]
+
+        assert items, "expected the asset to surface"
+        assert all(i["kind"] == "asset" for i in items)
+        assert any(i["uid"] == asset_uid for i in items)
+
+    async def test_kind_actor_with_type_group_only(self, client: AsyncClient) -> None:
+        await _seed_actor(client, name="Data Eng Person", type="person")
+        group_uid = await _seed_actor(client, name="Data Eng Team", type="group")
+
+        response = await client.get(
+            "/api/v1/search",
+            params={"q": "data eng", "kind": "actor", "type": "group"},
+        )
+        items = response.json()["items"]
+
+        assert items, "expected the team to surface"
+        assert all(i["kind"] == "actor" for i in items)
+        assert all(i["type"] == "group" for i in items)
+        assert any(i["uid"] == group_uid for i in items)
+
+    async def test_repeated_kind_ors_within_kinds(self, client: AsyncClient) -> None:
+        asset_uid = await _seed_asset(client, name="Customer Data")
+        actor_uid = await _seed_actor(client, name="Customer Dan")
+        await _seed_rule(client, name="Customer Data Quality", description="x")
+
+        response = await client.get(
+            "/api/v1/search",
+            params=[("q", "customer"), ("kind", "asset"), ("kind", "actor")],
+        )
+        items = response.json()["items"]
+        kinds = {i["kind"] for i in items}
+
+        assert "asset" in kinds and "actor" in kinds
+        assert "rule" not in kinds
+        assert any(i["uid"] == asset_uid for i in items)
+        assert any(i["uid"] == actor_uid for i in items)
+
+    async def test_type_routes_per_kind(self, client: AsyncClient) -> None:
+        """`kinds=[asset,actor] & types=[dataset,person]` filters each kind by its own type."""
+        ds_uid = await _seed_asset(client, name="Customer Dataset", type="dataset")
+        await _seed_asset(client, name="Customer Report", type="report")
+        person_uid = await _seed_actor(client, name="Customer Dan", type="person")
+        await _seed_actor(client, name="Customer Crew", type="group")
+
+        response = await client.get(
+            "/api/v1/search",
+            params=[
+                ("q", "customer"),
+                ("kind", "asset"),
+                ("kind", "actor"),
+                ("type", "dataset"),
+                ("type", "person"),
+            ],
+        )
+        items = response.json()["items"]
+        uids = {i["uid"] for i in items}
+
+        assert ds_uid in uids
+        assert person_uid in uids
+        # Cross-type hits should be filtered out.
+        assert all(
+            (i["kind"] == "asset" and i["type"] == "dataset")
+            or (i["kind"] == "actor" and i["type"] == "person")
+            for i in items
+        )
+
+    async def test_kind_intersects_with_query_prefix(
+        self, client: AsyncClient
+    ) -> None:
+        """Wizard restricting to `actor` while user typed `ds:` → no hits."""
+        await _seed_asset(client, name="Customer Dataset", type="dataset")
+        await _seed_actor(client, name="Customer Dan")
+
+        response = await client.get(
+            "/api/v1/search",
+            params={"q": "ds:customer", "kind": "actor"},
+        )
+        items = response.json()["items"]
+
+        assert items == [], "explicit kind=actor must not fall through to assets"

--- a/packages/sdk-ts/openapi.json
+++ b/packages/sdk-ts/openapi.json
@@ -1308,6 +1308,48 @@
               "title": "Limit"
             },
             "description": "Max items to return"
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict results to one or more kinds (asset / actor / container / field / rule). Repeat the param for multiple values. Intersects with any `kind:` prefix typed in the query \u2014 wizards that already know what's valid for a step pass this so a globally-ranked top-N can't squeeze the relevant kind out.",
+              "title": "Kind"
+            },
+            "description": "Restrict results to one or more kinds (asset / actor / container / field / rule). Repeat the param for multiple values. Intersects with any `kind:` prefix typed in the query \u2014 wizards that already know what's valid for a step pass this so a globally-ranked top-N can't squeeze the relevant kind out."
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Type filter, applied per-kind: asset.type for `kind=asset` (dataset / report / process / system / hierarchical members), actor.type for `kind=actor` (person / group), and severity for `kind=rule` (info / warning / critical). Mixed-kind type lists are routed to the right bucket automatically.",
+              "title": "Type"
+            },
+            "description": "Type filter, applied per-kind: asset.type for `kind=asset` (dataset / report / process / system / hierarchical members), actor.type for `kind=actor` (person / group), and severity for `kind=rule` (info / warning / critical). Mixed-kind type lists are routed to the right bucket automatically."
           }
         ],
         "responses": {

--- a/packages/sdk-ts/src/types/api.ts
+++ b/packages/sdk-ts/src/types/api.ts
@@ -2190,6 +2190,10 @@ export interface operations {
                 q?: string;
                 /** @description Max items to return */
                 limit?: number;
+                /** @description Restrict results to one or more kinds (asset / actor / container / field / rule). Repeat the param for multiple values. Intersects with any `kind:` prefix typed in the query — wizards that already know what's valid for a step pass this so a globally-ranked top-N can't squeeze the relevant kind out. */
+                kind?: string[] | null;
+                /** @description Type filter, applied per-kind: asset.type for `kind=asset` (dataset / report / process / system / hierarchical members), actor.type for `kind=actor` (person / group), and severity for `kind=rule` (info / warning / critical). Mixed-kind type lists are routed to the right bucket automatically. */
+                type?: string[] | null;
             };
             header?: never;
             path?: never;

--- a/packages/ui/src/app/api/holocron/search/route.ts
+++ b/packages/ui/src/app/api/holocron/search/route.ts
@@ -1,17 +1,29 @@
 import { proxyText } from "@/lib/api-route";
 
 /**
- * GET /api/holocron/search?q=<query>&limit=<n>
+ * GET /api/holocron/search?q=<query>&limit=<n>&kind=...&type=...
  *
- * Thin proxy to the Python API's /search endpoint. The SDK doesn't wrap
- * this yet — when it does, swap the raw fetch for `holocron.search.query()`.
+ * Thin proxy to the Python API's /search endpoint.
+ *
+ * `kind` and `type` are repeatable: the wizards send the kinds and
+ * types they accept for a step so the API can apply the filter
+ * server-side (otherwise valid hits get squeezed out of the
+ * globally-ranked top-N before the client-side filter ever runs).
+ *
+ * The SDK doesn't wrap this yet — when it does, swap the raw fetch for
+ * `holocron.search.query()`.
  */
 export async function GET(request: Request) {
 	const { searchParams } = new URL(request.url);
 	const q = searchParams.get("q") ?? "";
 	const limit = searchParams.get("limit") ?? "50";
-	return proxyText(
-		`/api/v1/search?${new URLSearchParams({ q, limit })}`,
-		"Search",
-	);
+	// URLSearchParams here is built by hand so repeatable params keep
+	// their multiplicity through the proxy. The constructor's object
+	// form would coerce `kind=[a, b]` into a stringified array.
+	const upstream = new URLSearchParams();
+	upstream.set("q", q);
+	upstream.set("limit", limit);
+	for (const k of searchParams.getAll("kind")) upstream.append("kind", k);
+	for (const t of searchParams.getAll("type")) upstream.append("type", t);
+	return proxyText(`/api/v1/search?${upstream}`, "Search");
 }

--- a/packages/ui/src/components/features/search/entity-picker.tsx
+++ b/packages/ui/src/components/features/search/entity-picker.tsx
@@ -187,13 +187,28 @@ export function EntityPicker({
 	);
 	const typeSet = useMemo(() => (types && types.length > 0 ? new Set(types) : null), [types]);
 
+	// Forward the wizard's allow-list to the API so the kind/type
+	// filter applies *before* the top-N truncation. The previous
+	// implementation pulled a globally-ranked top-N and then filtered
+	// client-side, so a query that matched many other kinds first
+	// would return the allowed kind empty even when matches existed
+	// (#32). `filterHits` below stays as a defensive last pass for
+	// excludeUids and to handle servers that don't yet support these
+	// query params.
 	const { data } = useQuery<{ items: SearchItem[] }>({
-		queryKey: ["entity-picker", trimmed, fetchLimit],
+		queryKey: [
+			"entity-picker",
+			trimmed,
+			fetchLimit,
+			kinds ? [...kinds].sort() : null,
+			types ? [...types].sort() : null,
+		],
 		queryFn: async ({ signal }) => {
-			const params = new URLSearchParams({
-				q: trimmed,
-				limit: String(fetchLimit),
-			});
+			const params = new URLSearchParams();
+			params.set("q", trimmed);
+			params.set("limit", String(fetchLimit));
+			if (kinds) for (const k of kinds) params.append("kind", k);
+			if (types) for (const t of types) params.append("type", t);
 			const res = await fetch(`/api/holocron/search?${params}`, { signal });
 			if (!res.ok) throw new Error("search failed");
 			return (await res.json()) as { items: SearchItem[] };


### PR DESCRIPTION
Closes #32.

## Summary

Wizards (relation source/target, group membership, maintainers, attach-rule, apply-rule) fetched a **globally-ranked top-20** from \`/search\` and then dropped everything outside the wizard's allowed kinds *client-side*. As soon as a generic query matched many entities of other kinds first, the allowed kind frequently didn't survive the cut — the dropdown silently came back empty even when matching entities existed.

This PR pushes the filter all the way to the API so the top-N budget is spent on relevant kinds.

## API

- \`GET /api/v1/search\` now accepts two new repeatable query params:
  - \`kind\`: \`asset\` / \`actor\` / \`container\` / \`field\` / \`rule\` (intersects with any \`kind:\` prefix typed in the query — wizard-prescribed scope wins)
  - \`type\`: applied per-kind — \`asset.type\` for assets, \`actor.type\` for actors, \`severity\` for rules. Mixed-kind type lists route to the right bucket automatically (\`kinds=[asset,actor] & types=[dataset,person]\` works).
- Unknown values are dropped silently rather than 422'd; the route is link-clickable and strictness would only frustrate users.
- 5 new integration tests cover the new params + the parser-prefix intersection edge case.
- mypy baseline unchanged (27 → 27).

## SDK

- Regenerated \`docs/openapi.json\` + SDK \`types/api.ts\`; the new params surface on the search operation. No \`client.search()\` resource exists today, so no method-level change.

## UI

- \`EntityPicker\` forwards \`kinds\` and \`types\` as repeated query params. The defensive \`filterHits\` last pass stays as a fallback (graceful with an older API).
- \`/api/holocron/search\` proxy now preserves repeatable params instead of collapsing them into a stringified array (\`URLSearchParams\` constructor's object form would have flattened them).

## Test plan

- [x] \`pytest tests/integration/test_search.py::TestSearchKindAndTypeFilters\` — **5/5 pass first run**, including the explicit kind=actor + parser kind=asset edge case (must return empty, not silently widen).
- [x] mypy baseline unchanged.
- [x] UI typecheck + 94 vitest pass; lint clean on the changed files.
- [x] End-to-end through the running stack with the seed fixture: \`?q=Leia&kind=actor\` returns 20 actors only; \`?q=data&kind=actor&type=group\` returns 6 groups only.
- [ ] **Heads-up**: \`TestSearchEndpoint::test_matches_asset_by_name\` fails on this branch *and* on \`main-new\` baseline — it expects exact "customer" → 1 asset, but hybrid (semantic + FTS) ranking legitimately surfaces "Invoices" alongside "Customer Orders" because they're semantically adjacent. Worth a separate \`test(api):\` PR to update the assertion (or pin the test to literal-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)