### PR TITLE
fix(ui): pin wizard header + footer; only the body scrolls (#33)

### DIFF
--- a/packages/ui/src/components/features/add-consumers-wizard.tsx
+++ b/packages/ui/src/components/features/add-consumers-wizard.tsx
@@ -9,12 +9,13 @@ import {
 	Kbd,
 	useWizardAutoFocus,
 	useWizardFocus,
+	WizardBody,
+	WizardDialogContent,
 	WizardFocusProvider,
 } from "@/components/features/wizard-shared";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
-	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -203,7 +204,7 @@ function ConsumersFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 				if (!next) cancel();
 			}}
 		>
-			<DialogContent
+			<WizardDialogContent
 				className="sm:max-w-lg bg-card/90 backdrop-blur-xl border-primary/20"
 				onKeyDown={handleDialogKey}
 				onOpenAutoFocus={(e) => e.preventDefault()}
@@ -218,14 +219,16 @@ function ConsumersFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4 pt-1">
+				<WizardBody>
 					<p className="text-sm text-muted-foreground">
 						People or teams who use this asset. Add as many as you like — each becomes a{" "}
 						<code className="text-xs">uses</code> relation.
 					</p>
 
 					{picks.length > 0 && (
-						<div className="flex flex-wrap gap-1.5">
+						// Bound the chip stack so a long pick list scrolls within
+						// itself rather than crowding out the search input below.
+						<div className="flex flex-wrap gap-1.5 max-h-32 overflow-y-auto">
 							{picks.map((m, i) => {
 								const Icon = getActorTypeIcon(m.type);
 								return (
@@ -262,13 +265,13 @@ function ConsumersFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 						renderTail={renderTail}
 						onBackspaceEmpty={onBackspaceEmpty}
 					/>
-				</div>
+				</WizardBody>
 
-				<div className="text-[11px] text-muted-foreground/70 flex flex-wrap items-center gap-x-3 gap-y-1 pt-1">
+				<div className="text-[11px] text-muted-foreground/70 flex flex-wrap items-center gap-x-3 gap-y-1 pt-2">
 					<Kbd>↑↓</Kbd> pick · <Kbd>↵</Kbd> add · <Kbd>⌫</Kbd> remove last · <Kbd>⌃↵</Kbd> link all
 				</div>
 
-				<DialogFooter className="sm:justify-between gap-2 pt-2">
+				<DialogFooter className="sm:justify-between gap-2 pt-3">
 					<Button type="button" variant="ghost" onClick={cancel}>
 						Cancel
 					</Button>
@@ -281,7 +284,7 @@ function ConsumersFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 								: `Link ${picks.length} consumers`}
 					</Button>
 				</DialogFooter>
-			</DialogContent>
+			</WizardDialogContent>
 		</Dialog>
 	);
 }

--- a/packages/ui/src/components/features/apply-rule-wizard.tsx
+++ b/packages/ui/src/components/features/apply-rule-wizard.tsx
@@ -10,12 +10,13 @@ import {
 	Stepper,
 	useWizardAutoFocus,
 	useWizardFocus,
+	WizardBody,
+	WizardDialogContent,
 	WizardFocusProvider,
 } from "@/components/features/wizard-shared";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
-	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -251,7 +252,7 @@ function ApplyFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 				if (!nextOpen) cancel();
 			}}
 		>
-			<DialogContent
+			<WizardDialogContent
 				className="sm:max-w-lg bg-card/90 backdrop-blur-xl border-primary/20"
 				onKeyDown={handleDialogKey}
 				onOpenAutoFocus={(e) => e.preventDefault()}
@@ -266,8 +267,11 @@ function ApplyFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 					</DialogDescription>
 				</DialogHeader>
 
-				<Stepper current={stepIndex} total={steps.length} />
+				<div className="pt-3">
+					<Stepper current={stepIndex} total={steps.length} />
+				</div>
 
+				<WizardBody>
 				<div
 					key={step}
 					className="min-h-[200px] animate-in fade-in-0 slide-in-from-bottom-1 duration-300"
@@ -308,6 +312,7 @@ function ApplyFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 					)}
 					{step === "review" && <StepReview data={data} assetName={frame.params.assetName} />}
 				</div>
+				</WizardBody>
 
 				<HintStrip step={step} canBack={stepIndex > 0} />
 
@@ -345,7 +350,7 @@ function ApplyFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 						)}
 					</div>
 				</DialogFooter>
-			</DialogContent>
+			</WizardDialogContent>
 		</Dialog>
 	);
 }

--- a/packages/ui/src/components/features/attach-rule-to-asset-wizard.tsx
+++ b/packages/ui/src/components/features/attach-rule-to-asset-wizard.tsx
@@ -10,12 +10,13 @@ import {
 	Stepper,
 	useWizardAutoFocus,
 	useWizardFocus,
+	WizardBody,
+	WizardDialogContent,
 	WizardFocusProvider,
 } from "@/components/features/wizard-shared";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
-	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -226,7 +227,7 @@ function Flow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 				if (!n) cancel();
 			}}
 		>
-			<DialogContent
+			<WizardDialogContent
 				className="sm:max-w-lg bg-card/90 backdrop-blur-xl border-primary/20"
 				onKeyDown={handleDialogKey}
 				onOpenAutoFocus={(e) => e.preventDefault()}
@@ -241,8 +242,11 @@ function Flow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 					</DialogDescription>
 				</DialogHeader>
 
-				<Stepper current={stepIndex} total={STEPS.length} />
+				<div className="pt-3">
+					<Stepper current={stepIndex} total={STEPS.length} />
+				</div>
 
+				<WizardBody>
 				<div
 					key={step}
 					className="min-h-[200px] animate-in fade-in-0 slide-in-from-bottom-1 duration-300"
@@ -272,6 +276,7 @@ function Flow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 					)}
 					{step === "review" && <StepReview data={data} ruleName={frame.params.ruleName} />}
 				</div>
+				</WizardBody>
 
 				<HintStrip step={step} canBack={stepIndex > 0} />
 
@@ -309,7 +314,7 @@ function Flow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 						)}
 					</div>
 				</DialogFooter>
-			</DialogContent>
+			</WizardDialogContent>
 		</Dialog>
 	);
 }

--- a/packages/ui/src/components/features/create-asset-wizard.tsx
+++ b/packages/ui/src/components/features/create-asset-wizard.tsx
@@ -25,12 +25,13 @@ import {
 	Stepper,
 	useWizardAutoFocus,
 	useWizardFocus,
+	WizardBody,
+	WizardDialogContent,
 	WizardFocusProvider,
 } from "@/components/features/wizard-shared";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
-	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -171,7 +172,7 @@ export function CreateAssetWizard({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent
+			<WizardDialogContent
 				className="sm:max-w-lg bg-card/90 backdrop-blur-xl border-primary/20"
 				onOpenAutoFocus={(event) => {
 					// Focus is managed by useWizardAutoFocus hooks inside the tree —
@@ -205,7 +206,7 @@ export function CreateAssetWizard({
 						/>
 					)}
 				</WizardFocusProvider>
-			</DialogContent>
+			</WizardDialogContent>
 		</Dialog>
 	);
 }
@@ -382,8 +383,11 @@ function BaseFlow({
 				</DialogDescription>
 			</DialogHeader>
 
-			<Stepper current={stepIndex} total={totalSteps} />
+			<div className="pt-3">
+				<Stepper current={stepIndex} total={totalSteps} />
+			</div>
 
+			<WizardBody>
 			<div
 				key={step}
 				className="min-h-[240px] animate-in fade-in-0 slide-in-from-bottom-1 duration-300"
@@ -429,6 +433,7 @@ function BaseFlow({
 				)}
 				{step === "review" && <StepReview data={data} />}
 			</div>
+			</WizardBody>
 
 			<KeyboardHint step={step} canBack={stepIndex > 0} />
 
@@ -612,6 +617,7 @@ function EnrichmentHub({
 				<DialogDescription className="sr-only">Add more information to the asset</DialogDescription>
 			</DialogHeader>
 
+			<WizardBody>
 			<div className="space-y-4 pt-1">
 				<div>
 					<h3 className="text-xl font-semibold">Want to add more?</h3>
@@ -679,6 +685,7 @@ function EnrichmentHub({
 					</div>
 				)}
 			</div>
+			</WizardBody>
 
 			<div className="text-[11px] text-muted-foreground/70 flex flex-wrap items-center gap-x-3 gap-y-1 pt-1">
 				<Kbd>↑↓</Kbd> choose · <Kbd>↵</Kbd> open · <Kbd>⌃↵</Kbd> finish
@@ -1188,7 +1195,9 @@ function StepMaintainers({
 			</div>
 
 			{value.length > 0 && (
-				<div className="flex flex-wrap gap-1.5">
+				// Bound the chip stack so a long pick list scrolls within
+				// itself rather than crowding out the search input below.
+				<div className="flex flex-wrap gap-1.5 max-h-32 overflow-y-auto">
 					{value.map((m, i) => {
 						const Icon = getActorTypeIcon(m.actorType);
 						return (

--- a/packages/ui/src/components/features/create-relation-wizard.tsx
+++ b/packages/ui/src/components/features/create-relation-wizard.tsx
@@ -10,12 +10,13 @@ import {
 	Stepper,
 	useWizardAutoFocus,
 	useWizardFocus,
+	WizardBody,
+	WizardDialogContent,
 	WizardFocusProvider,
 } from "@/components/features/wizard-shared";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
-	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
@@ -242,7 +243,7 @@ function RelationFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent
+			<WizardDialogContent
 				className="sm:max-w-lg bg-card/90 backdrop-blur-xl border-primary/20"
 				onKeyDown={handleDialogKey}
 				onOpenAutoFocus={(event) => {
@@ -259,42 +260,46 @@ function RelationFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 					</DialogDescription>
 				</DialogHeader>
 
-				<Stepper current={stepIndex} total={steps.length} />
-
-				<div
-					key={step}
-					className="min-h-[200px] animate-in fade-in-0 slide-in-from-bottom-1 duration-300"
-				>
-					{step === "type" && (
-						<StepRelationType
-							value={data.type}
-							onCommit={(v) => {
-								setData((d) => ({ ...d, type: v }));
-								setTimeout(next, 90);
-							}}
-						/>
-					)}
-					{step === "source" && (
-						<StepEntityPicker
-							label="Who or what is the source?"
-							hint="The starting side of the relation."
-							value={data.source}
-							onChange={(v) => setData((d) => ({ ...d, source: v }))}
-							onEnter={() => canAdvance && next()}
-						/>
-					)}
-					{step === "target" && (
-						<StepEntityPicker
-							label="And the target?"
-							hint="The other side of the relation."
-							value={data.target}
-							onChange={(v) => setData((d) => ({ ...d, target: v }))}
-							excludeUid={data.source?.uid}
-							onEnter={() => canAdvance && next()}
-						/>
-					)}
-					{step === "review" && <StepReview data={data} />}
+				<div className="pt-3">
+					<Stepper current={stepIndex} total={steps.length} />
 				</div>
+
+				<WizardBody>
+					<div
+						key={step}
+						className="min-h-[200px] animate-in fade-in-0 slide-in-from-bottom-1 duration-300"
+					>
+						{step === "type" && (
+							<StepRelationType
+								value={data.type}
+								onCommit={(v) => {
+									setData((d) => ({ ...d, type: v }));
+									setTimeout(next, 90);
+								}}
+							/>
+						)}
+						{step === "source" && (
+							<StepEntityPicker
+								label="Who or what is the source?"
+								hint="The starting side of the relation."
+								value={data.source}
+								onChange={(v) => setData((d) => ({ ...d, source: v }))}
+								onEnter={() => canAdvance && next()}
+							/>
+						)}
+						{step === "target" && (
+							<StepEntityPicker
+								label="And the target?"
+								hint="The other side of the relation."
+								value={data.target}
+								onChange={(v) => setData((d) => ({ ...d, target: v }))}
+								excludeUid={data.source?.uid}
+								onEnter={() => canAdvance && next()}
+							/>
+						)}
+						{step === "review" && <StepReview data={data} />}
+					</div>
+				</WizardBody>
 
 				<HintStrip step={step} canBack={stepIndex > 0} />
 
@@ -332,7 +337,7 @@ function RelationFlow({ frame, isTop }: { frame: Frame; isTop: boolean }) {
 						)}
 					</div>
 				</DialogFooter>
-			</DialogContent>
+			</WizardDialogContent>
 		</Dialog>
 	);
 }

--- a/packages/ui/src/components/features/wizard-shared.tsx
+++ b/packages/ui/src/components/features/wizard-shared.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+	type ComponentProps,
 	createContext,
 	type KeyboardEvent,
 	type ReactNode,
@@ -13,6 +14,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { DialogContent } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import {
 	type GridNavOutcome,
@@ -23,6 +25,79 @@ import {
 
 export type { GridNavOutcome, ListboxNavOutcome };
 export { computeGridNavOutcome, computeListboxNavOutcome };
+
+/* ------------------------------------------------------------------ */
+/* Wizard scroll layout — pin header + footer, scroll only the body.   */
+/*                                                                    */
+/* `DialogContent` defaults to a single `overflow-y-auto` viewport     */
+/* spanning the whole dialog. Once a wizard has growing content       */
+/* (multi-pick chips, long picker results, tail "create new" rows),   */
+/* that single scroll region pushes the title + stepper + footer      */
+/* off-screen as the user scrolls — and on shorter laptop viewports   */
+/* the primary CTA can leave the visible area entirely (#33).         */
+/*                                                                    */
+/* `WizardDialogContent` swaps the primitive's grid/overflow defaults */
+/* for a flex-column layout and disables the inner scroll. Then       */
+/* `WizardBody` is the only scroll region inside, leaving the         */
+/* header (above) and footer (below) pinned.                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Drop-in replacement for `<DialogContent>` for any multi-step or
+ * picker-heavy wizard.
+ *
+ * Layout: `flex flex-col`, `max-h` preserved from the primitive, but
+ * `overflow` is moved inward. Use `<WizardBody>` for the section that
+ * should scroll (typically the step body / picker / chip list). Place
+ * `<DialogHeader>` above and `<DialogFooter>` below — they stay pinned.
+ */
+export function WizardDialogContent({
+	className,
+	children,
+	...props
+}: ComponentProps<typeof DialogContent>) {
+	return (
+		<DialogContent
+			className={cn(
+				// Reset the inherited grid + inner scroll, replace with a
+				// flex column whose only scroll region is `<WizardBody>`.
+				"!grid-cols-none flex flex-col gap-0 overflow-hidden",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</DialogContent>
+	);
+}
+
+/**
+ * The single scroll region inside a `<WizardDialogContent>`. Renders
+ * its children inside a `flex-1 min-h-0 overflow-y-auto` div so the
+ * surrounding header / footer stay pinned even when the body grows.
+ *
+ * `gap-4` matches the gap `<DialogContent>` used to apply across the
+ * whole dialog so the visual rhythm between header / body / footer
+ * stays unchanged on the converted wizards.
+ */
+export function WizardBody({
+	className,
+	children,
+	...props
+}: ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="wizard-body"
+			className={cn(
+				"flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 py-1 -mx-1 px-1",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</div>
+	);
+}
 
 /**
  * Small shared primitives used by every wizard so the visual language stays


### PR DESCRIPTION
Closes #33.

## Summary

Wizards inherited \`DialogContent\`'s single \`overflow-y-auto\` viewport, so as soon as the picker results / chip stack / "create new" tail options grew past the dialog height, the **title + stepper + footer scrolled out of view together**. On laptop viewports users could lose sight of the step indicator or the primary CTA mid-pick.

## Approach (issue's "smallest blast radius first")

1. **New primitives** in \`wizard-shared.tsx\`:
   - \`WizardDialogContent\` — drop-in replacement for \`DialogContent\` that overrides the inherited grid + inner-scroll with \`flex flex-col\`.
   - \`WizardBody\` — the only scroll region (\`flex-1 min-h-0 overflow-y-auto\`). Header + footer placed outside this region stay pinned.
2. **Converted the five picker-heavy wizards** the issue called out:
   - \`add-consumers-wizard\`
   - \`create-relation-wizard\`
   - \`attach-rule-to-asset-wizard\`
   - \`apply-rule-wizard\`
   - \`create-asset-wizard\` (both \`BaseFlow\` and \`EnrichmentHub\` phases — they share the same outer \`DialogContent\`).
   Other wizards keep plain \`DialogContent\` — none of them exhibit the symptom yet.
3. **Bounded the chip lists** in the two multi-pick wizards (\`add-consumers\`, \`create-asset → maintainers\`) to \`max-h-32 overflow-y-auto\`. Long pick lists now scroll within themselves instead of crowding out the search input.

## Test plan

- [x] UI typecheck clean.
- [x] \`bun test\` — 94/94 pass.
- [x] Lint slice on touched files — no new warnings (pre-existing complexity warnings in the wizards untouched by this PR).
- [x] Page renders (HTTP 200 against a live stack).
- [ ] **Manual sanity** would close the loop: open \`Add consumers\` with 8–10 picks at ~800px viewport, confirm header + footer stay pinned while only the chip/picker region scrolls. (My Playwright sandbox can't write to the home volume so I couldn't capture screenshots.)

## Out of scope

- The other wizards (rule create/edit, schema add-child, edit-asset, etc.) — they don't grow content past dialog height today; can convert later if any starts to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)