### PR TITLE
feat(ui): relations palette extension — Delete + Open source/target (#30)

### DIFF
--- a/packages/ui/src/components/features/relations/relations-section.tsx
+++ b/packages/ui/src/components/features/relations/relations-section.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Trash2Icon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -15,12 +15,33 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+	type FocusedEntity,
+	getFocusedEntity,
+	setFocusedEntity,
+} from "@/extensions";
 import { type DirectedRelation, useEntityRelations } from "@/hooks/use-entity-relations";
 import { getRelationStyle } from "@/lib/entity-styles";
 import { getRelationTypeIcon, RelationIcon } from "@/lib/icons";
 import { queryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
 import { EntityChip } from "./entity-chip";
+
+/** Build a transient FocusedEntity for the relation under the cursor. */
+function focusedFromRelation(item: DirectedRelation): FocusedEntity {
+	return {
+		kind: "relation",
+		entity: {
+			uid: item.relation.uid,
+			type: item.relation.type,
+			from_uid: item.relation.from_uid,
+			to_uid: item.relation.to_uid,
+			other_name: item.other.name,
+			other_uid: item.other.uid,
+			other_kind: item.other.entityType,
+		},
+	};
+}
 
 interface RelationsSectionProps {
 	entityUid: string;
@@ -76,6 +97,20 @@ export function RelationsSection({ entityUid, entityName }: RelationsSectionProp
 	const queryClient = useQueryClient();
 	const { data, isLoading, error } = useEntityRelations(entityUid);
 	const [deleteTarget, setDeleteTarget] = useState<DirectedRelation | null>(null);
+
+	// Stack-of-one for hover-publish: the previous focus (typically the
+	// parent entity) is captured before we overwrite, then put back on
+	// row leave. The unmount cleanup catches the edge case where the
+	// user navigates away while a row is still hovered.
+	const previousFocusRef = useRef<FocusedEntity | null>(null);
+	useEffect(() => {
+		return () => {
+			const current = getFocusedEntity();
+			if (current?.kind === "relation") {
+				setFocusedEntity(previousFocusRef.current);
+			}
+		};
+	}, []);
 
 	const deleteMutation = useMutation({
 		mutationFn: async (uid: string) => {
@@ -169,7 +204,31 @@ export function RelationsSection({ entityUid, entityName }: RelationsSectionProp
 								</div>
 								<ul className={cn("space-y-1.5 border-l-2 pl-3 ml-2", style.border)}>
 									{group.items.map((item) => (
-										<li key={item.relation.uid} className="flex items-center gap-2">
+										<li
+											key={item.relation.uid}
+											className="flex items-center gap-2"
+											// Hover-publish makes the ⌘K palette show
+											// relation-scoped commands (Delete relation,
+											// Open source/target) for the row under the
+											// cursor. The previous focus (the parent
+											// entity) is captured before we overwrite so
+											// leaving the row restores it cleanly.
+											onMouseEnter={() => {
+												const prev = getFocusedEntity();
+												previousFocusRef.current = prev;
+												setFocusedEntity(focusedFromRelation(item));
+											}}
+											onMouseLeave={() => {
+												// Only restore if we're still the publisher
+												// — otherwise a different row already took
+												// over and we shouldn't clobber its focus.
+												const current = getFocusedEntity();
+												if (current?.kind === "relation"
+													&& current.entity.uid === item.relation.uid) {
+													setFocusedEntity(previousFocusRef.current);
+												}
+											}}
+										>
 											<EntityChip
 												uid={item.other.uid}
 												name={item.other.name}

--- a/packages/ui/src/extensions/built-in/actions.ts
+++ b/packages/ui/src/extensions/built-in/actions.ts
@@ -16,10 +16,14 @@ export const actionsExtension: Extension = {
 	id: "actions",
 	name: "Actions",
 	description: "Cross-cutting verbs for the focused entity.",
-	when: (ctx) => ctx.focused !== null,
+	// Relations are transient (hover-published from the relations
+	// sidebar) and don't have a verify flow — keep the actions
+	// extension scoped to persistent kinds.
+	when: (ctx) =>
+		ctx.focused !== null && ctx.focused.kind !== "relation",
 	commands: (ctx) => {
 		const focused = ctx.focused;
-		if (!focused) return [];
+		if (!focused || focused.kind === "relation") return [];
 		const { entity } = focused;
 		const queryClient = ctx.queryClient;
 

--- a/packages/ui/src/extensions/built-in/events.ts
+++ b/packages/ui/src/extensions/built-in/events.ts
@@ -13,10 +13,13 @@ export const eventsExtension: Extension = {
 	id: "events",
 	name: "History",
 	description: "Audit trail for the focused entity.",
-	when: (ctx) => ctx.focused !== null,
+	// Relations have no audit-trail wizard surface (events are recorded
+	// against persistent entities, not transient hover-publishes).
+	when: (ctx) =>
+		ctx.focused !== null && ctx.focused.kind !== "relation",
 	commands: (ctx) => {
 		const focused = ctx.focused;
-		if (!focused) return [];
+		if (!focused || focused.kind === "relation") return [];
 		return [
 			{
 				id: "show-history",

--- a/packages/ui/src/extensions/built-in/pins.ts
+++ b/packages/ui/src/extensions/built-in/pins.ts
@@ -6,8 +6,8 @@ import {
 	type LucideIcon,
 	RuleIcon,
 } from "@/lib/icons";
-import { addPin, isPinned, removePin } from "../pins-store";
-import type { Extension, ExtensionCommand, FocusedEntity } from "../types";
+import { addPin, isPinned, type PinnedEntity, removePin } from "../pins-store";
+import type { Extension, ExtensionCommand } from "../types";
 
 /**
  * Pins — the sticky counterpart to recents.
@@ -27,9 +27,11 @@ export const pinsExtension: Extension = {
 	commands: (ctx): ExtensionCommand[] => {
 		const cmds: ExtensionCommand[] = [];
 
-		// Toggle command for the focused entity.
+		// Toggle command for the focused entity. Relations are transient
+		// hover-publishes from the relations sidebar — we never want to
+		// persist them as a bookmark, so skip the toggle for that kind.
 		const focused = ctx.focused;
-		if (focused) {
+		if (focused && focused.kind !== "relation") {
 			const pinned = isPinned(focused.entity.uid);
 			if (pinned) {
 				cmds.push({
@@ -84,13 +86,13 @@ export const pinsExtension: Extension = {
 	},
 };
 
-function kindHint(focused: FocusedEntity): string {
+function kindHint(focused: PinnedEntity): string {
 	if (focused.kind === "asset") return `${focused.entity.type} · asset`;
 	if (focused.kind === "actor") return `${focused.entity.type} · actor`;
 	return `${focused.entity.severity} · rule`;
 }
 
-function iconFor(focused: FocusedEntity): LucideIcon {
+function iconFor(focused: PinnedEntity): LucideIcon {
 	if (focused.kind === "asset") return assetTypeIcons[focused.entity.type] ?? Bookmark;
 	if (focused.kind === "actor") return actorTypeIcons[focused.entity.type] ?? Bookmark;
 	return RuleIcon;

--- a/packages/ui/src/extensions/built-in/recents.ts
+++ b/packages/ui/src/extensions/built-in/recents.ts
@@ -5,7 +5,11 @@ import {
 	RuleIcon,
 	type LucideIcon,
 } from "@/lib/icons";
-import type { Extension, ExtensionCommand, FocusedEntity } from "../types";
+import type {
+	Extension,
+	ExtensionCommand,
+	PersistedFocusedEntity,
+} from "../types";
 
 /**
  * Recently viewed — projects the recents store into ⌘K commands so the
@@ -48,19 +52,19 @@ export const recentsExtension: Extension = {
 
 /** Detail-page URL for a focused entity. Mirrors the routing in
  *  `app/{kind}s/[uid]/page.tsx`. */
-function hrefFor(focused: FocusedEntity): string | null {
+function hrefFor(focused: PersistedFocusedEntity): string | null {
 	return `/${focused.kind}s/${focused.entity.uid}`;
 }
 
 /** A short subtitle that disambiguates entries with the same name and
  *  reminds the user what kind they were looking at. */
-function kindHint(focused: FocusedEntity): string {
+function kindHint(focused: PersistedFocusedEntity): string {
 	if (focused.kind === "asset") return `${focused.entity.type} · asset`;
 	if (focused.kind === "actor") return `${focused.entity.type} · actor`;
 	return `${focused.entity.severity} · rule`;
 }
 
-function iconFor(focused: FocusedEntity): LucideIcon {
+function iconFor(focused: PersistedFocusedEntity): LucideIcon {
 	if (focused.kind === "asset") {
 		return assetTypeIcons[focused.entity.type] ?? History;
 	}

--- a/packages/ui/src/extensions/built-in/relation.ts
+++ b/packages/ui/src/extensions/built-in/relation.ts
@@ -1,0 +1,123 @@
+import { ArrowLeft, ArrowRight, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { queryKeys } from "@/lib/query-keys";
+import { openConfirmWizard } from "@/lib/wizard-store";
+import { getRelationStyle } from "@/lib/entity-styles";
+import type { Extension, ExtensionContext } from "../types";
+
+/**
+ * Relation extension — palette commands for the relation in focus.
+ *
+ * Unlike Asset/Actor/Rule there is no relation detail page; the
+ * focus is published transiently from the relations sidebar
+ * (`relations-section.tsx`) on row hover so a user can press ⌘K and
+ * act on the relation they're looking at.
+ *
+ * Commands track the actor/asset extension shape: a "Danger" delete
+ * matching the inline trash icon's flow, plus two "Navigation"
+ * shortcuts to jump to the connected entities. "Edit relation type /
+ * metadata" is intentionally deferred — relations are immutable on
+ * the API side today (no PUT /relations/{uid}) so an Edit command
+ * would just delete-and-recreate behind the scenes, and that's a
+ * different UX call worth making explicitly.
+ */
+export const relationExtension: Extension = {
+	id: "relation",
+	name: "Relation",
+	description: "Delete and navigate the focused relation.",
+	when: (ctx) => ctx.focused?.kind === "relation",
+	commands: (ctx: ExtensionContext) => {
+		if (ctx.focused?.kind !== "relation") return [];
+		const rel = ctx.focused.entity;
+		const queryClient = ctx.queryClient;
+		const style = getRelationStyle(rel.type);
+		const verb = style.label.toLowerCase();
+
+		const otherDetailHref = (() => {
+			switch (rel.other_kind) {
+				case "asset":
+					return `/assets/${rel.other_uid}`;
+				case "actor":
+					return `/actors/${rel.other_uid}`;
+				case "rule":
+					return `/rules/${rel.other_uid}`;
+			}
+		})();
+
+		// `from_uid` and `to_uid` aren't always one of asset/actor/rule
+		// individually — but the relations sidebar already filters to
+		// rendered counterparties, so the focused row's `other_*` is
+		// always resolvable. The "source" / "target" commands link to
+		// the *current* page entity vs the counterparty using the
+		// from/to direction relative to the focused row.
+		const isOtherTarget = rel.to_uid === rel.other_uid;
+		const sourceHref = isOtherTarget ? null : otherDetailHref;
+		const targetHref = isOtherTarget ? otherDetailHref : null;
+
+		const cmds = [];
+
+		// Open source / target — at most one is "the other side" depending
+		// on direction, so we surface the one that actually navigates.
+		if (sourceHref) {
+			cmds.push({
+				id: "open-source",
+				label: `Open source: ${rel.other_name}`,
+				hint: `Jump to the ${rel.other_kind}`,
+				keywords: ["open", "source", "from", "navigate"],
+				group: "Navigation",
+				icon: ArrowLeft,
+				order: 10,
+				run: () => {
+					window.location.href = sourceHref;
+				},
+			});
+		}
+		if (targetHref) {
+			cmds.push({
+				id: "open-target",
+				label: `Open target: ${rel.other_name}`,
+				hint: `Jump to the ${rel.other_kind}`,
+				keywords: ["open", "target", "to", "navigate"],
+				group: "Navigation",
+				icon: ArrowRight,
+				order: 20,
+				run: () => {
+					window.location.href = targetHref;
+				},
+			});
+		}
+
+		cmds.push({
+			id: "delete",
+			label: "Delete relation",
+			hint: `Remove the “${verb}” link to ${rel.other_name}`,
+			keywords: ["delete", "remove", "unlink", verb],
+			group: "Danger",
+			icon: Trash2,
+			order: 99,
+			run: async () => {
+				const ok = await openConfirmWizard({
+					title: "Delete relation",
+					entityLabel: `${verb} → ${rel.other_name}`,
+					description:
+						"This removes only this link between the two entities. Neither side is deleted. This cannot be undone.",
+				});
+				if (!ok) return;
+				try {
+					const res = await fetch(`/api/holocron/relations/${rel.uid}`, {
+						method: "DELETE",
+					});
+					if (!res.ok && res.status !== 204) {
+						throw new Error(`Failed (${res.status})`);
+					}
+					queryClient?.invalidateQueries({ queryKey: queryKeys.relations.all });
+					toast.success(`Removed link to “${rel.other_name}”`);
+				} catch (err) {
+					toast.error(err instanceof Error ? err.message : "Something went wrong");
+				}
+			},
+		});
+
+		return cmds;
+	},
+};

--- a/packages/ui/src/extensions/built-in/share.ts
+++ b/packages/ui/src/extensions/built-in/share.ts
@@ -14,7 +14,11 @@ export const shareExtension: Extension = {
 	id: "share",
 	name: "Share",
 	description: "Clipboard actions for the focused entity.",
-	when: (ctx) => ctx.focused !== null,
+	// Relations are transient (hover-publish from the relations sidebar)
+	// and don't have a paste-into-Slack story, so the Share command set
+	// stays scoped to the persistent kinds (asset / actor / rule).
+	when: (ctx) =>
+		ctx.focused !== null && ctx.focused.kind !== "relation",
 	commands: (ctx) => {
 		const focused = ctx.focused;
 		if (!focused) return [];
@@ -115,7 +119,7 @@ function toMarkdown(focused: FocusedEntity): string {
 		}
 		lines.push("");
 		lines.push(`UID: \`${a.uid}\``);
-	} else {
+	} else if (focused.kind === "rule") {
 		const r = focused.entity;
 		lines.push(`### ${r.name}`);
 		lines.push("");

--- a/packages/ui/src/extensions/focused-entity.ts
+++ b/packages/ui/src/extensions/focused-entity.ts
@@ -54,11 +54,14 @@ export function useFocusedEntity(): FocusedEntity | null {
  *
  * Side effect: a non-null entity is also pushed onto the recents store, so
  * "Recently viewed" updates without each detail page having to opt in.
+ * Relations are skipped here — they're transient focus surfaces (hover
+ * over a row in the relations sidebar) and don't belong in "Recently
+ * viewed", which is reserved for things you actually navigated to.
  */
 export function useSetFocusedEntity(entity: FocusedEntity | null): void {
 	useEffect(() => {
 		setFocusedEntity(entity);
-		if (entity) pushRecent(entity);
+		if (entity && entity.kind !== "relation") pushRecent(entity);
 		const ours = entity;
 		return () => {
 			if (current === ours) setFocusedEntity(null);

--- a/packages/ui/src/extensions/host.tsx
+++ b/packages/ui/src/extensions/host.tsx
@@ -15,6 +15,7 @@ import { governanceExtension } from "./built-in/governance";
 import { navigationExtension } from "./built-in/navigation";
 import { pinsExtension } from "./built-in/pins";
 import { recentsExtension } from "./built-in/recents";
+import { relationExtension } from "./built-in/relation";
 import { ruleExtension } from "./built-in/rule";
 import { shareExtension } from "./built-in/share";
 import { useFocusedEntity } from "./focused-entity";
@@ -53,6 +54,7 @@ const BUILT_IN_EXTENSIONS: readonly Extension[] = [
 	assetNavExtension,
 	actorExtension,
 	ruleExtension,
+	relationExtension,
 	devToolsExtension,
 ];
 for (const ext of BUILT_IN_EXTENSIONS) registerExtension(ext);

--- a/packages/ui/src/extensions/index.ts
+++ b/packages/ui/src/extensions/index.ts
@@ -33,4 +33,5 @@ export type {
 	FocusedEntityKind,
 	FocusedAsset,
 	FocusedActor,
+	FocusedRelation,
 } from "./types";

--- a/packages/ui/src/extensions/pins-store.ts
+++ b/packages/ui/src/extensions/pins-store.ts
@@ -1,7 +1,10 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
-import type { FocusedEntity } from "./types";
+import type { FocusedEntity, PersistedFocusedEntity } from "./types";
+
+/** Alias kept for callers that imported the old name. */
+export type PinnedEntity = PersistedFocusedEntity;
 
 /**
  * Pinned-entity store — localStorage-backed bookmarks.
@@ -18,7 +21,7 @@ import type { FocusedEntity } from "./types";
 
 const STORAGE_KEY = "holocron.pins.v1";
 
-let pins: FocusedEntity[] = [];
+let pins: PinnedEntity[] = [];
 let hydrated = false;
 const listeners = new Set<() => void>();
 
@@ -32,7 +35,7 @@ function hydrate(): void {
 		const parsed = JSON.parse(raw);
 		if (Array.isArray(parsed)) {
 			// Light shape check — anything unrecognised is dropped silently.
-			pins = parsed.filter(isFocusedEntity);
+			pins = parsed.filter(isPinnedEntity);
 		}
 	} catch {
 		// Corrupt JSON or storage error — fall back to empty.
@@ -53,7 +56,7 @@ function emit(): void {
 	for (const l of listeners) l();
 }
 
-function isFocusedEntity(value: unknown): value is FocusedEntity {
+function isPinnedEntity(value: unknown): value is PinnedEntity {
 	if (typeof value !== "object" || value === null) return false;
 	const v = value as Record<string, unknown>;
 	if (v.kind !== "asset" && v.kind !== "actor" && v.kind !== "rule") return false;
@@ -62,7 +65,7 @@ function isFocusedEntity(value: unknown): value is FocusedEntity {
 	return typeof e.uid === "string" && typeof e.name === "string";
 }
 
-export function getPins(): readonly FocusedEntity[] {
+export function getPins(): readonly PinnedEntity[] {
 	hydrate();
 	return pins;
 }
@@ -74,6 +77,9 @@ export function isPinned(uid: string): boolean {
 
 export function addPin(entity: FocusedEntity): void {
 	hydrate();
+	// Relations are transient and never pinned — see the PinnedEntity
+	// type comment.
+	if (entity.kind === "relation") return;
 	if (pins.some((p) => p.entity.uid === entity.entity.uid)) return;
 	pins = [entity, ...pins];
 	persist();
@@ -104,8 +110,8 @@ function subscribe(cb: () => void): () => void {
 	};
 }
 
-const EMPTY: readonly FocusedEntity[] = [];
+const EMPTY: readonly PinnedEntity[] = [];
 
-export function usePins(): readonly FocusedEntity[] {
+export function usePins(): readonly PinnedEntity[] {
 	return useSyncExternalStore(subscribe, getPins, () => EMPTY);
 }

--- a/packages/ui/src/extensions/recents-store.ts
+++ b/packages/ui/src/extensions/recents-store.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
-import type { FocusedEntity } from "./types";
+import type { FocusedEntity, PersistedFocusedEntity } from "./types";
 
 /**
  * Recently-viewed entity store — module-level pub/sub, no persistence.
@@ -23,7 +23,7 @@ import type { FocusedEntity } from "./types";
 
 const MAX_RECENTS = 10;
 
-let recents: FocusedEntity[] = [];
+let recents: PersistedFocusedEntity[] = [];
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -31,6 +31,10 @@ function emit(): void {
 }
 
 export function pushRecent(entity: FocusedEntity): void {
+	// Relations are transient (hover-publish) and never enter recents.
+	// Filtering at the boundary keeps the in-memory list narrow and
+	// matches PersistedFocusedEntity's contract.
+	if (entity.kind === "relation") return;
 	const uid = entity.entity.uid;
 	const filtered = recents.filter((r) => r.entity.uid !== uid);
 	const next = [entity, ...filtered].slice(0, MAX_RECENTS);
@@ -43,7 +47,7 @@ export function pushRecent(entity: FocusedEntity): void {
 	emit();
 }
 
-export function getRecents(): readonly FocusedEntity[] {
+export function getRecents(): readonly PersistedFocusedEntity[] {
 	return recents;
 }
 
@@ -60,8 +64,8 @@ function subscribe(cb: () => void): () => void {
 	};
 }
 
-const EMPTY: readonly FocusedEntity[] = [];
+const EMPTY: readonly PersistedFocusedEntity[] = [];
 
-export function useRecents(): readonly FocusedEntity[] {
+export function useRecents(): readonly PersistedFocusedEntity[] {
 	return useSyncExternalStore(subscribe, getRecents, () => EMPTY);
 }

--- a/packages/ui/src/extensions/types.ts
+++ b/packages/ui/src/extensions/types.ts
@@ -55,14 +55,43 @@ export interface FocusedActor {
 	updated_at: string;
 }
 
+/**
+ * A relation focused for palette commands. Unlike Asset/Actor/Rule
+ * there is no relation detail page; this gets published transiently
+ * (e.g. on hover in the relations sidebar) so commands like
+ * "Delete relation", "Open source", "Open target" can target the
+ * specific edge currently in view.
+ */
+export interface FocusedRelation {
+	uid: string;
+	type: string;
+	from_uid: string;
+	to_uid: string;
+	/**
+	 * Display label for the counterparty entity ("Sales Data",
+	 * "Princess Leia"). Used by command labels so the user can tell
+	 * which row they're acting on at a glance.
+	 */
+	other_name: string;
+	other_uid: string;
+	other_kind: "asset" | "actor" | "rule";
+}
+
 /** The entity in focus on the current page, if any. Detail pages publish
  *  themselves through `useSetFocusedEntity`. */
 export type FocusedEntity =
 	| { kind: "asset"; entity: FocusedAsset }
 	| { kind: "actor"; entity: FocusedActor }
-	| { kind: "rule"; entity: Rule };
+	| { kind: "rule"; entity: Rule }
+	| { kind: "relation"; entity: FocusedRelation };
 
 export type FocusedEntityKind = FocusedEntity["kind"];
+
+/** Entities that get persisted into recents / pins. Relations are
+ *  transient (hover-publish from the relations sidebar) and never
+ *  participate. The runtime stores filter on this same constraint;
+ *  this type just makes the contract explicit to consumers. */
+export type PersistedFocusedEntity = Exclude<FocusedEntity, { kind: "relation" }>;
 
 /** Snapshot of the world an extension reasons about when producing its
  *  commands. The `queryClient` is injected by the host so extensions can
@@ -79,11 +108,11 @@ export interface ExtensionContext {
 	/** Most-recently-visited entities, newest first. Capped (see
 	 *  `recents-store.ts`). Empty when the user hasn't visited any detail
 	 *  pages this session. */
-	recents: readonly FocusedEntity[];
+	recents: readonly PersistedFocusedEntity[];
 	/** User-pinned bookmarks, persisted in localStorage. Distinct from
 	 *  recents: pins are sticky and curated, recents are session-only and
 	 *  auto-pruned. */
-	pins: readonly FocusedEntity[];
+	pins: readonly PersistedFocusedEntity[];
 }
 
 /**


### PR DESCRIPTION
Closes #30.

## Summary

Every other first-class entity kind has a built-in palette extension (\`actor.ts\`, \`asset.ts\`, \`rule.ts\`) — relations didn't, even though all the API + proxy + section UI plumbing already existed. This PR closes the asymmetry.

## What's new

- **\`extensions/built-in/relation.ts\`** mirroring the actor/asset shape:
  - **\`Delete relation\`** in a "Danger" group, using the same \`openConfirmWizard\` + toast + cache-invalidate flow the inline trash icon uses (so you can pick whichever entry point feels closer at the moment).
  - **\`Open source\` / \`Open target\`** in a "Navigation" group — surfaces whichever side is the counterparty for the focused row, so jumping along the relation graph is one ⌘K away.
- **Edit relation type / metadata** is intentionally deferred — the API has no \`PUT /relations/{uid}\` today, so an Edit command would silently delete-and-recreate, which is a different UX call worth making explicitly. (Mirrors the pre-existing "Known limitations" comment in the MCP server's README.)

## Wiring

- New \`FocusedRelation\` variant on \`FocusedEntity\`, used as a **transient** focus publish from \`relations-section.tsx\` on row hover so ⌘K surfaces the new commands for whichever relation the cursor is on. The previous focus (the parent entity) is captured before the overwrite and restored on row leave / section unmount.
- New \`PersistedFocusedEntity\` type narrows recents + pins to the kinds that actually have a detail page. \`pushRecent\` and \`addPin\` filter relations at the boundary — they're hover-state, not navigation history.
- \`actions\`, \`events\`, \`share\` extensions tightened to \`kind !== "relation"\` — none of those flows apply to a transient edge (no verify, no audit-trail wizard, no Slack-paste markdown).

## Test plan

- [x] UI typecheck clean (no new errors; type narrowing flushed through every consumer that switched on \`kind\`).
- [x] \`bun test\` — 94/94 pass.
- [x] Lint slice on touched files — no new warnings.
- [x] Page renders (HTTP 200 against \`/\` and \`/assets/<uid>\`).
- [ ] **Manual sanity** would close it: open an asset detail, hover a relations-sidebar row, press ⌘K → see "Delete relation" in Danger and "Open source/target" in Navigation. (Sandbox Playwright can't get a browser session up to capture this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)