### PR TITLE
fix(ui): pin lineage canvas to h-[60vh] so ReactFlow can measure it

### DIFF
--- a/packages/ui/src/components/features/lineage/lineage-graph.tsx
+++ b/packages/ui/src/components/features/lineage/lineage-graph.tsx
@@ -288,8 +288,17 @@ function LineageGraphInner({
 			{/* Graph canvas. Until the initial relations + rules fetches
 			    complete we show only the spinner — otherwise the user would
 			    watch the centre node pop in, then edges, then rules, which
-			    reads as a glitchy half-loaded graph. */}
-			<div className="flex-1 min-h-[320px] w-full rounded-lg border border-primary/15 bg-background/20 relative overflow-hidden">
+			    reads as a glitchy half-loaded graph.
+			    Fixed `h-[60vh]` instead of `flex-1` because the page's
+			    `<main>` uses `min-h-[…]` (PR #19, to allow page-level
+			    scroll on tall wizards). With an unbounded parent height
+			    `flex-1` can't grow, so ReactFlow's ResizeObserver reads
+			    a 0-height container and refuses to render — that's the
+			    "React Flow parent container needs a width and a height"
+			    warning. Pinning to a viewport-relative height decouples
+			    the canvas from the flex chain entirely and stays
+			    responsive without breaking the page's scroll model. */}
+			<div className="h-[60vh] min-h-[320px] w-full rounded-lg border border-primary/15 bg-background/20 relative overflow-hidden">
 				{isInitialLoading ? (
 					<LoadingOverlay />
 				) : (


### PR DESCRIPTION
## Summary

Lineage graph rendered as a **completely empty area** on every node detail page. Browser console showed:

> [React Flow]: The React Flow parent container needs a width and a height to render the graph.

No API failure — the relations data was loading correctly. Pure layout regression.

## Root cause

[#19](https://github.com/squat-collective/holocron/pull/19) changed \`<main>\` on every detail page from a fixed \`h-[calc(100dvh-…)]\` to a \`min-h-[…]\` so tall wizards / long detail pages could scroll past the viewport.

Side-effect: \`flex-1\` only fills its parent when the parent has a **bounded** height. With \`min-h\` parents, every \`flex-1\` between \`<main>\` and the lineage canvas wrapper stopped expanding — so the wrapper at \`flex-1 min-h-[320px]\` sometimes measured as 0 px to ReactFlow's \`ResizeObserver\` (timing-dependent), and ReactFlow refused to render.

## Fix

Drop \`flex-1\` and pin the wrapper to \`h-[60vh] min-h-[320px]\`. Decouples the canvas from the broken flex chain entirely, keeps the 320 px floor for short viewports, leaves the page-level scroll model from #19 untouched.

## Test plan

- [x] UI typecheck clean.
- [x] Manually verified the graph renders on \`/assets/asset-raw-coruscant-docking\` (an asset with 1 outgoing FEEDS + 3 incoming relations against the seed fixture).
- [x] No console warnings on lineage tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)