### PR TITLE
feat(mcp): schema tools — author containers + fields without round-tripping the asset

### DIFF
--- a/packages/mcp-server/CLAUDE.md
+++ b/packages/mcp-server/CLAUDE.md
@@ -63,6 +63,11 @@ tests/
 | `create_rule` / `update_rule` / `delete_rule` | Rule CRUD.                                                |
 | `list_rules_for_asset`                       | Rules attached to an asset, with enforcement context.     |
 | `attach_rule` / `detach_rule`                | Wire a rule to an asset (creates `APPLIES_TO` relation).  |
+| `get_asset_schema` | Read an asset's schema tree (containers + fields).                                |
+| `add_schema_container` | Add a container (table / sheet / page / section / …) to an asset's schema.     |
+| `add_schema_field` | Add a field (column / measure / attribute / …) under a container.                 |
+| `update_schema_node` | Rename, change description, toggle pii, etc. on any container or field.         |
+| `delete_schema_node` | Remove a container (with its descendants) or a field.                           |
 | `get_entity`      | Polymorphic resolver — given any UID, return the typed payload (asset / actor / rule). |
 | `search`          | Case-insensitive substring match across assets + actors.                           |
 | `list_tags`       | Distinct tags across the catalog with usage counts (sorted by count desc).         |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -14,6 +14,7 @@ Part of the [Holocron monorepo](../../README.md). Cross-cutting docs in [`docs/`
 | **Actors** | `list_actors`, `get_actor`, `create_actor`, `update_actor`, `delete_actor`, `verify_actor` |
 | **Relations** | `list_relations`, `get_relation`, `create_relation`, `delete_relation`, `verify_relation` |
 | **Rules** | `list_rules`, `get_rule`, `create_rule`, `update_rule`, `delete_rule`, `list_rules_for_asset`, `attach_rule`, `detach_rule` |
+| **Schema** | `get_asset_schema`, `add_schema_container`, `add_schema_field`, `update_schema_node`, `delete_schema_node` — author the `metadata.schema` tree of containers + fields without round-tripping the full asset. |
 | **Resolver** | `get_entity` — UID → typed payload (asset / actor / rule), so AI agents don't have to guess the label |
 | **Catalog-wide** | `search` — substring match across assets + actors; `list_tags`; `get_graph_map` (LOD 0/1); `list_events` |
 | **Plugins** | `list_plugins`, `run_plugin` (file inputs by host path) |

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
 /**
  * Thin wrapper around the Holocron SDK plus a few raw endpoints the SDK
  * doesn't yet surface (plugins, verified flag).
@@ -6,8 +8,6 @@
  * combined client used by every tool handler.
  */
 import { HolocronClient } from "@squat-collective/holocron-ts";
-import { readFile } from "node:fs/promises";
-import { basename } from "node:path";
 
 /**
  * Options for constructing the MCP Holocron client.
@@ -335,12 +335,10 @@ export function createHolocronMcpClient(options: McpClientOptions): McpHolocronC
 			}
 		},
 		listRulesForAsset: async (assetUid) => {
-			const res = await request(
-				`/api/v1/rules/for-asset/${encodeURIComponent(assetUid)}`,
-				{ method: "GET" },
-			);
-			if (!res.ok)
-				throw new Error(`listRulesForAsset failed: ${res.status} ${res.statusText}`);
+			const res = await request(`/api/v1/rules/for-asset/${encodeURIComponent(assetUid)}`, {
+				method: "GET",
+			});
+			if (!res.ok) throw new Error(`listRulesForAsset failed: ${res.status} ${res.statusText}`);
 			const data = (await res.json()) as { items: AppliedRuleRecord[] };
 			return data.items ?? [];
 		},

--- a/packages/mcp-server/src/resources/catalog.ts
+++ b/packages/mcp-server/src/resources/catalog.ts
@@ -67,7 +67,8 @@ export function registerCatalogResources(server: McpServer, client: McpHolocronC
 		"holocron://schema-overview",
 		{
 			title: "Holocron Catalog Overview",
-			description: "Markdown summary of the catalog: asset/actor/relation counts and top-level structure.",
+			description:
+				"Markdown summary of the catalog: asset/actor/relation counts and top-level structure.",
 			mimeType: "text/markdown",
 		},
 		async (uri) => {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -4,7 +4,11 @@
  * the server without stdio.
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createHolocronMcpClient, type McpClientOptions, type McpHolocronClient } from "./client.js";
+import {
+	type McpClientOptions,
+	type McpHolocronClient,
+	createHolocronMcpClient,
+} from "./client.js";
 import { registerCatalogResources } from "./resources/index.js";
 import { registerTools } from "./tools/index.js";
 
@@ -27,8 +31,7 @@ export async function createServer(
 	options: CreateServerOptions,
 ): Promise<{ server: McpServer; client: McpHolocronClient }> {
 	const client =
-		options.client ??
-		createHolocronMcpClient({ baseUrl: options.baseUrl, token: options.token });
+		options.client ?? createHolocronMcpClient({ baseUrl: options.baseUrl, token: options.token });
 
 	const server = new McpServer(SERVER_INFO, {
 		capabilities: {

--- a/packages/mcp-server/src/tools/assets.ts
+++ b/packages/mcp-server/src/tools/assets.ts
@@ -157,7 +157,10 @@ export function registerAssetTools(server: McpServer, client: McpHolocronClient)
 				"Mark a discovered asset as verified. Use this once a human (or Claude acting on their behalf) has confirmed the asset is correctly documented. Optionally append a description note.",
 			inputSchema: {
 				uid: z.string().min(1),
-				description: z.string().optional().describe("Optional description to append with verification"),
+				description: z
+					.string()
+					.optional()
+					.describe("Optional description to append with verification"),
 			},
 		},
 		async ({ uid, description }): Promise<CallToolResult> => {

--- a/packages/mcp-server/src/tools/events.ts
+++ b/packages/mcp-server/src/tools/events.ts
@@ -29,9 +29,7 @@ export function registerEventTools(server: McpServer, client: McpHolocronClient)
 					.string()
 					.optional()
 					.describe("Filter to events that touched a specific entity."),
-				action: ActionEnum.optional().describe(
-					"Filter by action (created / updated / deleted).",
-				),
+				action: ActionEnum.optional().describe("Filter by action (created / updated / deleted)."),
 				limit: z.number().int().min(1).max(500).optional(),
 				offset: z.number().int().min(0).optional(),
 			},

--- a/packages/mcp-server/src/tools/graph.ts
+++ b/packages/mcp-server/src/tools/graph.ts
@@ -23,16 +23,12 @@ export function registerGraphTools(server: McpServer, client: McpHolocronClient)
 				lod: z
 					.union([z.literal(0), z.literal(1)])
 					.optional()
-					.describe(
-						"Level of detail: 0 = overview (systems + teams), 1 = full map (default).",
-					),
+					.describe("Level of detail: 0 = overview (systems + teams), 1 = full map (default)."),
 			},
 		},
 		async ({ lod }): Promise<CallToolResult> => {
 			try {
-				const map = await client.sdk.graph.map(
-					lod !== undefined ? { lod } : undefined,
-				);
+				const map = await client.sdk.graph.map(lod !== undefined ? { lod } : undefined);
 				return jsonResult(map);
 			} catch (err) {
 				return errorResult("get_graph_map", err);

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -11,18 +11,17 @@ import { registerGraphTools } from "./graph.js";
 import { registerPluginTools } from "./plugins.js";
 import { registerRelationTools } from "./relations.js";
 import { registerRuleTools } from "./rules.js";
+import { registerSchemaTools } from "./schema.js";
 import { registerSearchTool } from "./search.js";
 import { registerTagTools } from "./tags.js";
 
 /** Register all Holocron MCP tools on the given server. */
-export async function registerTools(
-	server: McpServer,
-	client: McpHolocronClient,
-): Promise<void> {
+export async function registerTools(server: McpServer, client: McpHolocronClient): Promise<void> {
 	registerAssetTools(server, client);
 	registerActorTools(server, client);
 	registerRelationTools(server, client);
 	registerRuleTools(server, client);
+	registerSchemaTools(server, client);
 	registerEntityTools(server, client);
 	registerSearchTool(server, client);
 	registerTagTools(server, client);
@@ -62,6 +61,12 @@ export const TOOL_NAMES = [
 	"list_rules_for_asset",
 	"attach_rule",
 	"detach_rule",
+	// schema (asset.metadata.schema authoring)
+	"get_asset_schema",
+	"add_schema_container",
+	"add_schema_field",
+	"update_schema_node",
+	"delete_schema_node",
 	// polymorphic resolver
 	"get_entity",
 	// catalog-wide

--- a/packages/mcp-server/src/tools/relations.ts
+++ b/packages/mcp-server/src/tools/relations.ts
@@ -9,14 +9,7 @@ import { z } from "zod";
 import type { McpHolocronClient } from "../client.js";
 import { errorResult, jsonResult } from "./helpers.js";
 
-const RELATION_TYPES = [
-	"owns",
-	"uses",
-	"feeds",
-	"contains",
-	"member_of",
-	"applies_to",
-] as const;
+const RELATION_TYPES = ["owns", "uses", "feeds", "contains", "member_of", "applies_to"] as const;
 const RelationTypeSchema = z.enum(RELATION_TYPES);
 
 export function registerRelationTools(server: McpServer, client: McpHolocronClient): void {
@@ -54,7 +47,8 @@ export function registerRelationTools(server: McpServer, client: McpHolocronClie
 		"get_relation",
 		{
 			title: "Get Relation",
-			description: "Fetch a single relation by UID. Returns from/to UIDs, type, properties, and verification state.",
+			description:
+				"Fetch a single relation by UID. Returns from/to UIDs, type, properties, and verification state.",
 			inputSchema: {
 				uid: z.string().min(1),
 			},

--- a/packages/mcp-server/src/tools/rules.ts
+++ b/packages/mcp-server/src/tools/rules.ts
@@ -60,7 +60,8 @@ export function registerRuleTools(server: McpServer, client: McpHolocronClient):
 		"get_rule",
 		{
 			title: "Get Rule",
-			description: "Fetch a single rule by UID — returns full name, description, severity, category.",
+			description:
+				"Fetch a single rule by UID — returns full name, description, severity, category.",
 			inputSchema: { uid: z.string().min(1) },
 		},
 		async ({ uid }): Promise<CallToolResult> => {

--- a/packages/mcp-server/src/tools/schema.ts
+++ b/packages/mcp-server/src/tools/schema.ts
@@ -1,0 +1,360 @@
+/**
+ * Schema tools — manage an asset's `metadata.schema` tree.
+ *
+ * The Holocron API stores schema (tables, sheets, columns, fields)
+ * as a nested JSON tree under `asset.metadata.schema`. The :Container
+ * and :Field nodes visible in search are read-only projections of
+ * that tree, regenerated on every asset write.
+ *
+ * The native API surface for editing schema is awkward: agents have
+ * to fetch the full asset, mutate the metadata blob, and PUT the
+ * whole thing back, while being careful not to drop tags / specs /
+ * any other metadata key. These tools wrap that round-trip into
+ * single-operation primitives so an agent can build a schema tree
+ * incrementally — add a container, add fields under it, rename a
+ * column, drop one — without seeing the metadata envelope.
+ *
+ * Paths use slash-joined names: `"orders/order_id"` resolves the
+ * `order_id` field inside the `orders` container at the root. The
+ * same shape that the materialised `:Container/:Field` projection
+ * uses for its `path` property, so navigating from a search hit to
+ * the right place in this tree is mechanical.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import type { McpHolocronClient } from "../client.js";
+import { errorResult, jsonResult } from "./helpers.js";
+
+/* ------------------------------------------------------------------ */
+/* Shape                                                               */
+/* ------------------------------------------------------------------ */
+
+interface ContainerNode {
+	id?: string;
+	name: string;
+	description?: string | null;
+	nodeType: "container";
+	containerType?: string | null;
+	children?: SchemaNode[];
+}
+
+interface FieldNode {
+	id?: string;
+	name: string;
+	description?: string | null;
+	nodeType: "field";
+	dataType?: string | null;
+	pii?: boolean;
+}
+
+type SchemaNode = ContainerNode | FieldNode;
+
+function readSchema(asset: { metadata?: Record<string, unknown> }): SchemaNode[] {
+	const raw = asset.metadata?.schema;
+	if (!Array.isArray(raw)) return [];
+	return raw as SchemaNode[];
+}
+
+/**
+ * Patch metadata with a new schema array, preserving every other key.
+ * Returns a fresh metadata object — the asset's original is left
+ * untouched so the caller can pass it straight to `update_asset`.
+ */
+function withSchema(
+	metadata: Record<string, unknown> | undefined,
+	schema: SchemaNode[],
+): Record<string, unknown> {
+	return { ...(metadata ?? {}), schema };
+}
+
+/**
+ * Walk a slash-joined path through the schema tree. Returns the
+ * matching node or null if any segment doesn't resolve.
+ */
+function findByPath(
+	tree: SchemaNode[],
+	path: string,
+): { node: SchemaNode; parent: SchemaNode[]; index: number } | null {
+	const segments = path.split("/").filter((s) => s.length > 0);
+	if (segments.length === 0) return null;
+	let cursor: SchemaNode[] = tree;
+	let last: { node: SchemaNode; parent: SchemaNode[]; index: number } | null = null;
+	for (const seg of segments) {
+		const idx = cursor.findIndex((n) => n.name === seg);
+		if (idx < 0) return null;
+		const node = cursor[idx];
+		if (!node) return null;
+		last = { node, parent: cursor, index: idx };
+		if (node.nodeType === "container") {
+			cursor = node.children ?? [];
+		} else {
+			// Reached a field — any further segments would be invalid.
+			cursor = [];
+		}
+	}
+	return last;
+}
+
+/**
+ * Resolve the children array under `parentPath`, or the root tree
+ * itself when parentPath is empty/undefined. Throws when the path
+ * resolves to a field (fields can't have children) or doesn't exist.
+ */
+function resolveChildren(tree: SchemaNode[], parentPath: string | undefined): SchemaNode[] {
+	if (!parentPath) return tree;
+	const found = findByPath(tree, parentPath);
+	if (!found) throw new Error(`parent path not found: ${parentPath}`);
+	if (found.node.nodeType !== "container") {
+		throw new Error(
+			`parent path resolves to a ${found.node.nodeType}, only containers can have children: ${parentPath}`,
+		);
+	}
+	if (!found.node.children) found.node.children = [];
+	return found.node.children;
+}
+
+function slugify(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+/* ------------------------------------------------------------------ */
+/* Registration                                                        */
+/* ------------------------------------------------------------------ */
+
+export function registerSchemaTools(server: McpServer, client: McpHolocronClient): void {
+	/* ---- read ---- */
+	server.registerTool(
+		"get_asset_schema",
+		{
+			title: "Read an Asset's Schema Tree",
+			description:
+				"Return the schema tree (containers + fields) under an asset's `metadata.schema`. Use this when you need to inspect the structure before editing.",
+			inputSchema: {
+				asset_uid: z.string().min(1),
+			},
+		},
+		async ({ asset_uid }): Promise<CallToolResult> => {
+			try {
+				const asset = await client.sdk.assets.get(asset_uid);
+				return jsonResult({
+					asset_uid,
+					schema: readSchema(asset as { metadata?: Record<string, unknown> }),
+				});
+			} catch (err) {
+				return errorResult("get_asset_schema", err);
+			}
+		},
+	);
+
+	/* ---- add container ---- */
+	server.registerTool(
+		"add_schema_container",
+		{
+			title: "Add a Schema Container",
+			description:
+				"Add a new container (table, sheet, page, section, …) to an asset's schema tree. With `parent_path`, the container is nested under that path; without it, the container is added at the root.",
+			inputSchema: {
+				asset_uid: z.string().min(1),
+				name: z.string().min(1).describe('Display name for the container, e.g. "orders"'),
+				container_type: z
+					.string()
+					.optional()
+					.describe(
+						"Sub-type the UI uses to pick an icon — e.g. table, sheet, page, section. Free-form; not validated.",
+					),
+				parent_path: z
+					.string()
+					.optional()
+					.describe("Slash-joined path of the parent container. Omit to add at the schema root."),
+				description: z.string().optional(),
+			},
+		},
+		async ({
+			asset_uid,
+			name,
+			container_type,
+			parent_path,
+			description,
+		}): Promise<CallToolResult> => {
+			try {
+				const asset = await client.sdk.assets.get(asset_uid);
+				const schema = readSchema(asset as { metadata?: Record<string, unknown> });
+				const container: ContainerNode = {
+					id: slugify(name) || undefined,
+					name,
+					description: description ?? null,
+					nodeType: "container",
+					containerType: container_type ?? null,
+					children: [],
+				};
+				const target = resolveChildren(schema, parent_path);
+				target.push(container);
+				const updated = await client.sdk.assets.update(asset_uid, {
+					metadata: withSchema((asset as { metadata?: Record<string, unknown> }).metadata, schema),
+				});
+				return jsonResult({
+					asset_uid,
+					added_path: parent_path ? `${parent_path}/${name}` : name,
+					schema: readSchema(updated as { metadata?: Record<string, unknown> }),
+				});
+			} catch (err) {
+				return errorResult("add_schema_container", err);
+			}
+		},
+	);
+
+	/* ---- add field ---- */
+	server.registerTool(
+		"add_schema_field",
+		{
+			title: "Add a Schema Field",
+			description:
+				"Add a field (column, measure, attribute, …) to an asset's schema tree. `parent_path` must point at an existing container.",
+			inputSchema: {
+				asset_uid: z.string().min(1),
+				name: z.string().min(1).describe('Display name for the field, e.g. "order_id"'),
+				parent_path: z
+					.string()
+					.min(1)
+					.describe("Slash-joined path of the container this field belongs to."),
+				data_type: z
+					.string()
+					.optional()
+					.describe("Free-form type label, e.g. string / integer / uuid / timestamp."),
+				pii: z.boolean().optional(),
+				description: z.string().optional(),
+			},
+		},
+		async ({
+			asset_uid,
+			name,
+			parent_path,
+			data_type,
+			pii,
+			description,
+		}): Promise<CallToolResult> => {
+			try {
+				const asset = await client.sdk.assets.get(asset_uid);
+				const schema = readSchema(asset as { metadata?: Record<string, unknown> });
+				const field: FieldNode = {
+					id: slugify(name) || undefined,
+					name,
+					description: description ?? null,
+					nodeType: "field",
+					dataType: data_type ?? null,
+					pii: pii ?? false,
+				};
+				const target = resolveChildren(schema, parent_path);
+				target.push(field);
+				const updated = await client.sdk.assets.update(asset_uid, {
+					metadata: withSchema((asset as { metadata?: Record<string, unknown> }).metadata, schema),
+				});
+				return jsonResult({
+					asset_uid,
+					added_path: `${parent_path}/${name}`,
+					schema: readSchema(updated as { metadata?: Record<string, unknown> }),
+				});
+			} catch (err) {
+				return errorResult("add_schema_field", err);
+			}
+		},
+	);
+
+	/* ---- update node ---- */
+	server.registerTool(
+		"update_schema_node",
+		{
+			title: "Update a Schema Node",
+			description:
+				"Update a container or field at the given path. Only the fields you pass are changed; everything else is left as-is. Renaming via `name` updates the path consumers reference, so update any callers afterwards.",
+			inputSchema: {
+				asset_uid: z.string().min(1),
+				path: z.string().min(1).describe("Slash-joined path of the node to update."),
+				name: z.string().optional(),
+				description: z.string().optional(),
+				container_type: z.string().optional().describe("Only meaningful on container nodes."),
+				data_type: z.string().optional().describe("Only meaningful on field nodes."),
+				pii: z.boolean().optional().describe("Only meaningful on field nodes."),
+			},
+		},
+		async ({
+			asset_uid,
+			path,
+			name,
+			description,
+			container_type,
+			data_type,
+			pii,
+		}): Promise<CallToolResult> => {
+			try {
+				const asset = await client.sdk.assets.get(asset_uid);
+				const schema = readSchema(asset as { metadata?: Record<string, unknown> });
+				const found = findByPath(schema, path);
+				if (!found) {
+					return errorResult("update_schema_node", new Error(`path not found: ${path}`));
+				}
+				const node = found.node;
+				if (name !== undefined) node.name = name;
+				if (description !== undefined) node.description = description;
+				if (container_type !== undefined && node.nodeType === "container") {
+					node.containerType = container_type;
+				}
+				if (data_type !== undefined && node.nodeType === "field") {
+					node.dataType = data_type;
+				}
+				if (pii !== undefined && node.nodeType === "field") {
+					node.pii = pii;
+				}
+				const updated = await client.sdk.assets.update(asset_uid, {
+					metadata: withSchema((asset as { metadata?: Record<string, unknown> }).metadata, schema),
+				});
+				return jsonResult({
+					asset_uid,
+					updated_node: node,
+					schema: readSchema(updated as { metadata?: Record<string, unknown> }),
+				});
+			} catch (err) {
+				return errorResult("update_schema_node", err);
+			}
+		},
+	);
+
+	/* ---- delete node ---- */
+	server.registerTool(
+		"delete_schema_node",
+		{
+			title: "Delete a Schema Node",
+			description:
+				"Remove a container or field at the given path. Containers are deleted *with* their descendants (no orphan check) — to keep the children, move them out via `add_*` first.",
+			inputSchema: {
+				asset_uid: z.string().min(1),
+				path: z.string().min(1),
+			},
+		},
+		async ({ asset_uid, path }): Promise<CallToolResult> => {
+			try {
+				const asset = await client.sdk.assets.get(asset_uid);
+				const schema = readSchema(asset as { metadata?: Record<string, unknown> });
+				const found = findByPath(schema, path);
+				if (!found) {
+					return errorResult("delete_schema_node", new Error(`path not found: ${path}`));
+				}
+				found.parent.splice(found.index, 1);
+				const updated = await client.sdk.assets.update(asset_uid, {
+					metadata: withSchema((asset as { metadata?: Record<string, unknown> }).metadata, schema),
+				});
+				return jsonResult({
+					asset_uid,
+					removed_path: path,
+					schema: readSchema(updated as { metadata?: Record<string, unknown> }),
+				});
+			} catch (err) {
+				return errorResult("delete_schema_node", err);
+			}
+		},
+	);
+}

--- a/packages/mcp-server/tests/server.test.ts
+++ b/packages/mcp-server/tests/server.test.ts
@@ -5,13 +5,12 @@
  * require a live Holocron API.
  */
 import { describe, expect, test } from "bun:test";
-import { createServer } from "../src/server.js";
 import type { McpHolocronClient } from "../src/client.js";
+import { createServer } from "../src/server.js";
 import { TOOL_NAMES } from "../src/tools/index.js";
 
 function makeFakeClient(): McpHolocronClient {
 	const empty = async () => ({ items: [], total: 0 });
-	// biome-ignore lint/suspicious/noExplicitAny: test fake
 	const sdk = {
 		assets: {
 			list: empty,
@@ -47,6 +46,7 @@ function makeFakeClient(): McpHolocronClient {
 		events: {
 			list: async () => ({ items: [], total: 0 }),
 		},
+		// biome-ignore lint/suspicious/noExplicitAny: test fake
 	} as any;
 
 	return {
@@ -102,6 +102,12 @@ describe("createServer", () => {
 			"list_rules_for_asset",
 			"attach_rule",
 			"detach_rule",
+			// schema (asset.metadata.schema authoring)
+			"get_asset_schema",
+			"add_schema_container",
+			"add_schema_field",
+			"update_schema_node",
+			"delete_schema_node",
 			// polymorphic resolver
 			"get_entity",
 			// catalog-wide


### PR DESCRIPTION
## Summary

The MCP catalog had a glaring gap: agents could create assets, actors, relations, rules, etc., but there was **no clean way to author the schema tree** (containers + fields). The API only exposes schema through \`asset.metadata.schema\` JSON — to add a column an agent had to fetch the full asset, mutate the metadata blob in place, and PUT the whole thing back, without accidentally dropping tags / specs / custom keys / anything else under \`metadata\`. Surgery the model could trip on, with no helpful error if it did.

This PR closes that gap with **5 new MCP tools** that wrap the round-trip:

| Tool | Purpose |
|---|---|
| \`get_asset_schema(asset_uid)\` | Return the schema array directly. |
| \`add_schema_container(asset_uid, name, parent_path?, container_type?, description?)\` | Add a container at root or nested under a path. |
| \`add_schema_field(asset_uid, parent_path, name, data_type?, pii?, description?)\` | Add a field under an existing container. |
| \`update_schema_node(asset_uid, path, name?/description?/container_type?/data_type?/pii?)\` | Patch any node in place. |
| \`delete_schema_node(asset_uid, path)\` | Remove a container (with its descendants) or a field. |

Brings the MCP tool count to **37**. Also covers the \`pii\` flag end-to-end so glossary-style authoring (mark this column PII) takes one call.

## Path syntax

\`path\` is slash-joined names: \`orders/order_id\` resolves the \`order_id\` field inside the \`orders\` container at the root. Same shape the materialised \`:Container\` / \`:Field\` projection uses for its \`path\` property, so navigating from a \`search\` hit straight to the right node is mechanical.

## Why MCP-only (no API endpoints)

These tools are pure compositions of \`get_asset\` + JSON mutation + \`update_asset\`. Adding API endpoints would duplicate the surface and risk drift between the JSON-based authoring (UI wizards) and a parallel REST surface. Keep one source of truth, give MCP a thin ergonomic layer over it.

## Test plan

- [x] \`bun test\` — 2/2 pass with the updated TOOL_NAMES count (37).
- [x] \`bun run lint\` — clean.
- [x] \`bun build\` — bundle 0.89 MB, no errors.
- [x] \`tools/list\` over stdio reports all 5 schema tools.
- [x] **End-to-end against live API**: cleared an asset's metadata, then ran \`add_schema_container("orders", "table") → add_schema_field("orders/order_id", "uuid") → add_schema_field("orders/customer_email", "string", pii=true)\` through the stdio MCP server. Direct API readback shows the 1-table / 2-column tree exactly as authored, with the PII flag preserved on \`customer_email\`. Cleaned up at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)