### PR TITLE
chore(ci): mark *-alpha tags as prerelease in the release.yml fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,12 +183,30 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ steps.version.outputs.tag }}"
+          # release-please applies `prerelease: true` + `make_latest: false`
+          # itself when it cuts an alpha/beta/rc; this fallback only kicks
+          # in when a tag was pushed manually (release-please's PR-create
+          # path was blocked, etc.). Mirror its behaviour so manually-tagged
+          # alphas don't accidentally claim "Latest" over the real stable.
+          PRERELEASE_FLAGS=()
+          if [[ "$TAG" =~ -(alpha|beta|rc) ]]; then
+            PRERELEASE_FLAGS=(--prerelease --latest=false)
+          fi
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             # Manual-tag fallback. release-please normally beats us here.
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$TAG" \
-              --notes "Install instructions: see [README](https://github.com/$GITHUB_REPOSITORY#quick-start)."
+              --notes "Install instructions: see [README](https://github.com/$GITHUB_REPOSITORY#quick-start)." \
+              "${PRERELEASE_FLAGS[@]}"
+          elif [[ ${#PRERELEASE_FLAGS[@]} -gt 0 ]]; then
+            # Release already exists (release-please path), but if the tag
+            # is a prerelease we still ensure the flags are right — covers
+            # the case where the manual-PR branch was used and the release
+            # was created via the same fallback path on a prior run.
+            gh release edit "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              "${PRERELEASE_FLAGS[@]}" >/dev/null
           fi
           gh release upload "$TAG" \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary

The \"Ensure release exists, attach assets\" step in \`release.yml\` runs \`gh release create\` when a tag arrives without release-please having created the release first (manual-tag path, used three times this week because the repo's "Allow Actions to create PRs" setting is off).

Until now that fallback skipped \`--prerelease\`, so manually-tagged \`vX.Y.Z-alpha\` releases ended up marked **stable AND "Latest"** — overshadowing the real stable on the release page. After every release I had to manually \`gh release edit --prerelease\` and \`gh api -X PATCH … make_latest=false\`. Three releases ago that was a one-off, now it's friction.

## Change

Sniff the tag for \`-alpha\`/\`-beta\`/\`-rc\` and pass \`--prerelease --latest=false\` for those. Mirrors what release-please itself sets when its happy path runs.

For tags that already exist (e.g. release-please did create the release on an earlier run), the same flags are reapplied via \`gh release edit\` so any release left in the wrong state by a previous fallback gets repaired on the next workflow run against the same tag.

## Out of scope (related)

The other recurring papercut is **\"Allow GitHub Actions to create and approve pull requests"** in repo settings — that's a UI toggle, not a code change. Once flipped, release-please will open + tag itself again and this fallback path will mostly stop firing. Worth flipping when you're next in the repo settings.

## Test plan

- [x] No code paths beyond the workflow — nothing to unit-test in isolation.
- [x] Visual diff of the bash matches the intended behaviour.
- [ ] First real verification: the next time release-please's branch is created and a tag fires, the release will be auto-flagged correctly. Will confirm on the next bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)